### PR TITLE
chore: update metabase helm repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ cluster-down:
 
 deps:
 	helm repo add bitnami https://charts.bitnami.com/bitnami
-	helm repo add metabase https://helm.chartmuseum.metabase.com
+	helm repo add metabase https://helm.metabase.com
 	helm repo update
 	buf --version >/dev/null 2>&1 || go install github.com/bufbuild/buf/cmd/buf@latest
 

--- a/charts/platform/Chart.yaml
+++ b/charts/platform/Chart.yaml
@@ -10,4 +10,4 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
   - name: metabase
     version: 1.1.0
-    repository: https://helm.chartmuseum.metabase.com
+    repository: https://helm.metabase.com


### PR DESCRIPTION
## Summary
- use new Metabase Helm repository URL

## Testing
- `helm repo add metabase https://helm.metabase.com` *(fails: command not found)*
- `helm repo update` *(fails: command not found)*
- `make deps` *(fails: helm: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cc5f35ddc832589b0815219f452e3