### PR TITLE
fix: update Metabase Helm repository

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ cluster-down:
 
 deps:
 	helm repo add bitnami https://charts.bitnami.com/bitnami
-	helm repo add metabase https://helm.metabase.com
+	helm repo add metabase https://metabase.github.io/helm-charts
 	helm repo update
 	buf --version >/dev/null 2>&1 || go install github.com/bufbuild/buf/cmd/buf@latest
 

--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ A minimal personal data platform running on a local k3d Kubernetes cluster. It p
 ## Quickstart
 ```bash
 make cluster-up        # create k3d cluster
-make deps              # install helm repos, buf, etc.
+make deps              # install Helm repos (Bitnami \& Metabase) and buf
 make install-core      # install Postgres + Metabase
 make build-app         # build ingest-service jar and container
 make deploy            # deploy ingest-service and CronJob
-```
+The `deps` target adds the Bitnami and Metabase Helm repositories, using the official Metabase chart repo at https://metabase.github.io/helm-charts.
 
 Drop CSV files into `storage/incoming/`. The CronJob scans every 10 minutes and moves processed files to `storage/processed/`.
 

--- a/charts/platform/Chart.yaml
+++ b/charts/platform/Chart.yaml
@@ -10,4 +10,4 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
   - name: metabase
     version: 1.1.0
-    repository: https://helm.metabase.com
+    repository: https://metabase.github.io/helm-charts


### PR DESCRIPTION
## Summary
- point Metabase Helm references at the maintained repository
- document new Metabase chart repo in setup instructions

## Testing
- `make deps` *(fails: helm: command not found)*
- `apt-get install -y helm` *(fails: Unable to locate package helm)*

------
https://chatgpt.com/codex/tasks/task_e_689cc7a30db08325b6d39253afb8f3c0