### PR TITLE
Run Metabase via Docker instead of Helm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,6 @@ cluster-down:
 
 deps:
 	helm repo add bitnami https://charts.bitnami.com/bitnami
-	helm repo add metabase https://metabase.github.io/helm-charts
 	helm repo update
 	buf --version >/dev/null 2>&1 || go install github.com/bufbuild/buf/cmd/buf@latest
 

--- a/charts/platform/Chart.yaml
+++ b/charts/platform/Chart.yaml
@@ -8,6 +8,3 @@ dependencies:
   - name: postgresql
     version: 12.1.0
     repository: https://charts.bitnami.com/bitnami
-  - name: metabase
-    version: 1.1.0
-    repository: https://metabase.github.io/helm-charts

--- a/charts/platform/values.local.sops.yaml
+++ b/charts/platform/values.local.sops.yaml
@@ -3,7 +3,3 @@ postgresql:
   auth:
     username: ENC[AES256_GCM,data:abcd,iv:abcd,tag:abcd,type:str]
     password: ENC[AES256_GCM,data:abcd,iv:abcd,tag:abcd,type:str]
-metabase:
-  admin:
-    password: ENC[AES256_GCM,data:abcd,iv:abcd,tag:abcd,type:str]
-    email: ENC[AES256_GCM,data:abcd,iv:abcd,tag:abcd,type:str]

--- a/charts/platform/values.yaml
+++ b/charts/platform/values.yaml
@@ -8,17 +8,6 @@ postgresql:
     username: user
     database: personal
 
-metabase:
-  service:
-    type: LoadBalancer
-  database:
-    type: postgresql
-    host: postgresql.personal.svc.cluster.local
-    port: 5432
-    dbname: personal
-    user: user
-    password: changeme
-
 ingestService:
   image: ingest-service:latest
   env:

--- a/ops/metabase/README.md
+++ b/ops/metabase/README.md
@@ -1,3 +1,17 @@
 # Metabase Ops
 
-Placeholder for seed scripts or notes.
+Start Metabase without Helm using the official Docker image:
+
+```bash
+kubectl port-forward svc/platform-postgresql 5432:5432 -n personal &
+docker run -d -p 8080:3000 --name metabase \
+  -e MB_DB_TYPE=postgres \
+  -e MB_DB_DBNAME=personal \
+  -e MB_DB_PORT=5432 \
+  -e MB_DB_USER=user \
+  -e MB_DB_PASS=changeme \
+  -e MB_DB_HOST=host.docker.internal \
+  metabase/metabase
+```
+
+Then open <http://localhost:8080> to finish the Metabase setup.


### PR DESCRIPTION
## Summary
- drop Metabase Helm chart dependency and values
- document running Metabase using the official Docker image
- clean up Makefile and local secrets

## Testing
- `make deps` *(fails: helm: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cc9986dc883259bf2d655ec5a9638