### PR TITLE
Make platform chart namespace creation optional

### DIFF
--- a/charts/platform/templates/namespace.yaml
+++ b/charts/platform/templates/namespace.yaml
@@ -1,4 +1,6 @@
+{{- if .Values.namespaceCreate }}
 apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ .Values.namespace }}
+{{- end }}

--- a/charts/platform/values.yaml
+++ b/charts/platform/values.yaml
@@ -1,4 +1,5 @@
 namespace: personal
+namespaceCreate: false
 
 postgresql:
   primary:


### PR DESCRIPTION
## Summary
- Allow skipping namespace creation in platform chart
- Default `namespaceCreate` to false

## Testing
- `helm lint charts/platform` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cd99037f88325a02c7e6c5b603c4a