### PR TITLE
chore: adjust buf generation command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ install-core:
 	helm upgrade --install platform charts/platform -n $(NAMESPACE) -f charts/platform/values.yaml -f charts/platform/values.local.sops.yaml --create-namespace
 
 build-app:
-	buf generate ops/proto
+	cd ops/proto && buf generate
 	cd apps/ingest-service && ./gradlew bootJar && docker build -t ingest-service:latest .
 
 deploy:


### PR DESCRIPTION
## Summary
- run `buf generate` from the ops/proto directory when building the app

## Testing
- `make build-app` *(fails: could not unmarshal as YAML: line 2: field workspace not found in type bufconfig.ExternalConfigV1)*

------
https://chatgpt.com/codex/tasks/task_e_689ce015a62c8325b321f4564f12171e