### PR TITLE
chore: simplify buf module configuration

### DIFF
--- a/ops/proto/buf.yaml
+++ b/ops/proto/buf.yaml
@@ -1,4 +1,1 @@
 version: v1
-workspace:
-  directories:
-    - .


### PR DESCRIPTION
## Summary
- remove workspace settings from buf.yaml to keep only module version

## Testing
- `cd ops/proto && buf generate` *(fails: the server hosted at that remote is unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_689ce44fae988325bec213e2d9a0b346