### PR TITLE
Generate gradle wrapper jar during build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ install-core:
 
 build-app:
 	cd ops/proto && buf generate
-	cd apps/ingest-service && ./gradlew bootJar && docker build -t ingest-service:latest .
+	cd apps/ingest-service && (test -f gradle/wrapper/gradle-wrapper.jar || gradle wrapper --gradle-version 8.4) && ./gradlew bootJar && docker build -t ingest-service:latest .
 
 deploy:
 	helm upgrade --install platform charts/platform -n $(NAMESPACE) -f charts/platform/values.yaml -f charts/platform/values.local.sops.yaml


### PR DESCRIPTION
## Summary
- ignore Gradle wrapper JARs instead of committing binaries
- generate wrapper JAR on demand in `make build-app`

## Testing
- `gradle wrapper --gradle-version 8.4`
- `./gradlew tasks`
- `make build-app` *(fails: the server hosted at that remote is unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_689ce65714d88325ac8f04fa6d41df63