### PR TITLE
chore: target Java 17 for ingest-service build

### DIFF
--- a/apps/ingest-service/build.gradle
+++ b/apps/ingest-service/build.gradle
@@ -8,7 +8,7 @@ plugins {
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'
-java.sourceCompatibility = JavaVersion.VERSION_21
+java.sourceCompatibility = JavaVersion.VERSION_17
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
## Summary
- compile ingest-service against Java 17 instead of 21

## Testing
- `./gradlew test`
- `make build-app` *(fails: Failure: the server hosted at that remote is unavailable.)*


------
https://chatgpt.com/codex/tasks/task_e_689d08bac8e08325add47cb9e3ade89b