### PR TITLE
chore: remove protobuf gradle plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 apps/ingest-service/build/
 apps/ingest-service/.gradle/
 **/gradle-wrapper.jar
+apps/ingest-service/src/generated/

--- a/apps/ingest-service/build.gradle
+++ b/apps/ingest-service/build.gradle
@@ -3,7 +3,6 @@ plugins {
     id 'io.spring.dependency-management' version '1.1.3'
     id 'java'
     id 'nu.studer.jooq' version '9.0'
-    id 'com.google.protobuf' version '0.9.4'
 }
 
 group = 'com.example'
@@ -33,7 +32,6 @@ sourceSets {
     main {
         java { srcDir 'src/generated/java' }
         resources { srcDir '../../ops/sql' }
-        proto { srcDir '../../ops/proto' }
     }
 }
 
@@ -42,10 +40,6 @@ jooq {
     configurations {
         main { generateSchemaSourceOnCompilation = false }
     }
-}
-
-protobuf {
-    protoc { artifact = 'com.google.protobuf:protoc:3.24.3' }
 }
 
 tasks.withType(Test) {


### PR DESCRIPTION
## Summary
- remove com.google.protobuf Gradle plugin and related config
- ignore generated sources

## Testing
- `buf generate ops/proto` *(fails: the server hosted at that remote is unavailable)*
- `make build-app` *(fails: the server hosted at that remote is unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_689d10604b688325a066c34d5908c116