### PR TITLE
chore: update protobuf to v4.27

### DIFF
--- a/apps/ingest-service/build.gradle
+++ b/apps/ingest-service/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-jooq'
     implementation 'org.flywaydb:flyway-core'
     implementation 'com.opencsv:opencsv:5.9'
-    implementation 'com.google.protobuf:protobuf-java:3.24.3'
+    implementation 'com.google.protobuf:protobuf-java:4.27.2'
     implementation 'org.apache.poi:poi-ooxml:5.2.3'
     runtimeOnly 'org.postgresql:postgresql'
     implementation 'commons-codec:commons-codec:1.15'

--- a/ops/proto/buf.gen.yaml
+++ b/ops/proto/buf.gen.yaml
@@ -1,4 +1,4 @@
 version: v1
 plugins:
-  - plugin: buf.build/protocolbuffers/java
+  - plugin: buf.build/protocolbuffers/java:v27.2
     out: ../../apps/ingest-service/src/generated/java


### PR DESCRIPTION
## Summary
- update ingest-service to use protobuf-java 4.27.2
- pin buf Java plugin to v27.2 for consistent codegen

## Testing
- `make build-app` *(fails: the server hosted at that remote is unavailable)*
- `cd apps/ingest-service && ./gradlew bootJar`


------
https://chatgpt.com/codex/tasks/task_e_689d175278ec83258dce051a5170c011