### PR TITLE
use local helm helper to remove tilt extension dependency

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -1,4 +1,10 @@
-load('ext://helm', 'helm')
+def helm(name, chart, namespace='', values=[]):
+    cmd = ['helm', 'template', name, chart]
+    if namespace:
+        cmd += ['--namespace', namespace]
+    for v in values:
+        cmd += ['-f', v]
+    return local(cmd, echo_off=False).stdout
 
 helm_release = helm(
     name='platform',


### PR DESCRIPTION
## Summary
- define a simple `helm()` helper directly in the Tiltfile instead of relying on a missing `ext://helm` extension

## Testing
- `tilt ci --port=0 --timeout=1s` *(fails: "helm": executable file not found in $PATH)*

------
https://chatgpt.com/codex/tasks/task_e_689d1aa46fc08325afed53900ebaae4d