### PR TITLE
Fix Tilt Helm helper to return command output correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ make deps              # install Helm repo (Bitnami) and buf
 make install-core      # install Postgres
 make build-app         # build ingest-service jar and container
 make deploy            # deploy ingest-service and CronJob
+make tilt              # start Tilt for live updates
 ```
 
 Start Metabase in a separate terminal:

--- a/Tiltfile
+++ b/Tiltfile
@@ -4,7 +4,7 @@ def helm(name, chart, namespace='', values=[]):
         cmd += ['--namespace', namespace]
     for v in values:
         cmd += ['-f', v]
-    return local(cmd, echo_off=False).stdout
+    return local(cmd, echo_off=False)
 
 helm_release = helm(
     name='platform',


### PR DESCRIPTION
## Summary
- fix Tiltfile helm helper to return local command output directly
- document `make tilt` step for live updates

## Testing
- `tilt doctor`


------
https://chatgpt.com/codex/tasks/task_e_689d5a6e81088325bb11fefa9388e062