### PR TITLE
fix: route Tilt builds to local k3d registry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,17 @@ SHELL := /bin/bash
 
 CLUSTER_NAME ?= personal
 NAMESPACE ?= personal
+REGISTRY_NAME ?= $(CLUSTER_NAME)-registry
+REGISTRY_PORT ?= 5000
 
 cluster-up:
-	k3d cluster create $(CLUSTER_NAME) --servers 1 --agents 1 --port "8080:80@loadbalancer"
+	k3d cluster create $(CLUSTER_NAME) --servers 1 --agents 1 \
+	--port "8080:80@loadbalancer" \
+	--registry-create $(REGISTRY_NAME):0.0.0.0:$(REGISTRY_PORT)
 
 cluster-down:
 	k3d cluster delete $(CLUSTER_NAME) || true
+	k3d registry delete $(REGISTRY_NAME) || true
 
 deps:
 	helm repo add bitnami https://charts.bitnami.com/bitnami

--- a/Tiltfile
+++ b/Tiltfile
@@ -1,3 +1,6 @@
+CLUSTER_NAME = read_env("CLUSTER_NAME", "personal")
+default_registry("k3d-%s-registry:5000" % CLUSTER_NAME)
+
 def helm(name, chart, namespace='', values=[]):
     cmd = ['helm', 'template', name, chart]
     if namespace:


### PR DESCRIPTION
## Summary
- spin up a k3d registry during `cluster-up` and clean it up on `cluster-down`
- configure Tilt to push images to the k3d registry instead of Docker Hub

## Testing
- `make cluster-up` *(fails: k3d: command not found)*
- `make build-app` *(fails: buf: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d5c2835908325be3bb318cc025c98