### PR TITLE
fix: guard registry deletion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,19 @@ SHELL := /bin/bash
 
 CLUSTER_NAME ?= personal
 NAMESPACE ?= personal
+REGISTRY_NAME ?= $(CLUSTER_NAME)-registry
+REGISTRY_PORT ?= 5000
 
 cluster-up:
-	k3d cluster create $(CLUSTER_NAME) --servers 1 --agents 1 --port "8080:80@loadbalancer"
+	k3d cluster create $(CLUSTER_NAME) --servers 1 --agents 1 \
+	--port "8080:80@loadbalancer" \
+	--registry-create $(REGISTRY_NAME):0.0.0.0:$(REGISTRY_PORT)
 
 cluster-down:
 	k3d cluster delete $(CLUSTER_NAME) || true
+	if k3d registry list 2>/dev/null | grep -q "$(REGISTRY_NAME)"; then \
+		k3d registry delete $(REGISTRY_NAME); \
+	fi || true
 
 deps:
 	helm repo add bitnami https://charts.bitnami.com/bitnami

--- a/Tiltfile
+++ b/Tiltfile
@@ -1,3 +1,6 @@
+CLUSTER_NAME = read_env("CLUSTER_NAME", "personal")
+default_registry("k3d-%s-registry:5000" % CLUSTER_NAME)
+
 def helm(name, chart, namespace='', values=[]):
     cmd = ['helm', 'template', name, chart]
     if namespace:


### PR DESCRIPTION
## Summary
- delete k3d registry only if it exists during cluster teardown

## Testing
- `make cluster-down` *(fails: k3d: command not found)*
- `make build-app` *(fails: buf: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d5c2835908325be3bb318cc025c98