### PR TITLE
Handle missing registry in cluster-down

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ cluster-up:
 
 cluster-down:
 	k3d cluster delete $(CLUSTER_NAME) || true
-	k3d registry delete $(REGISTRY_NAME) || true
+	k3d registry list $(REGISTRY_NAME) >/dev/null 2>&1 && k3d registry delete $(REGISTRY_NAME) || true
 
 deps:
 	helm repo add bitnami https://charts.bitnami.com/bitnami


### PR DESCRIPTION
## Summary
- check if registry exists before deletion in `make cluster-down`

## Testing
- `make cluster-down` *(fails: k3d: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d64d0f4a08325b0b731323e685321