### PR TITLE
Improve k3d cluster lifecycle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,13 +6,23 @@ REGISTRY_NAME ?= $(CLUSTER_NAME)-registry
 REGISTRY_PORT ?= 5000
 
 cluster-up:
+	@if k3d registry list $(REGISTRY_NAME) >/dev/null 2>&1; then \
+	echo "Using existing registry $(REGISTRY_NAME)"; \
+	REGISTRY_CMD="--registry-use k3d-$(REGISTRY_NAME):$(REGISTRY_PORT)"; \
+	else \
+	echo "Creating registry $(REGISTRY_NAME)"; \
+	REGISTRY_CMD="--registry-create $(REGISTRY_NAME):0.0.0.0:$(REGISTRY_PORT)"; \
+	fi; \
 	k3d cluster create $(CLUSTER_NAME) --servers 1 --agents 1 \
-	--port "8080:80@loadbalancer" \
-	--registry-create $(REGISTRY_NAME):0.0.0.0:$(REGISTRY_PORT)
+	--port "8080:80@loadbalancer" $$REGISTRY_CMD
 
 cluster-down:
 	k3d cluster delete $(CLUSTER_NAME) || true
 	k3d registry list $(REGISTRY_NAME) >/dev/null 2>&1 && k3d registry delete $(REGISTRY_NAME) || true
+
+clean: cluster-down
+	docker volume ls -q | grep '^k3d-$(CLUSTER_NAME)' | xargs -I{} docker volume rm {} || true
+	docker network ls -q | grep '^k3d-$(CLUSTER_NAME)' | xargs -I{} docker network rm {} || true
 
 deps:
 	helm repo add bitnami https://charts.bitnami.com/bitnami
@@ -33,4 +43,4 @@ deploy:
 tilt:
 	tilt up
 
-.PHONY: cluster-up cluster-down deps install-core build-app deploy tilt
+.PHONY: cluster-up cluster-down clean deps install-core build-app deploy tilt


### PR DESCRIPTION
## Summary
- make cluster-up resilient to existing registries by reusing or creating as needed
- add clean target to remove leftover k3d volumes and networks

## Testing
- `make clean` (fails: k3d: command not found; docker: command not found)
- `make cluster-up` (fails: k3d: command not found)


------
https://chatgpt.com/codex/tasks/task_e_689d6a53bc7c8325a2c92f0559954cd4