### PR TITLE
fix: avoid macOS port conflict for registry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL := /bin/bash
 CLUSTER_NAME ?= personal
 NAMESPACE ?= personal
 REGISTRY_NAME ?= $(CLUSTER_NAME)-registry
-REGISTRY_PORT ?= 5000
+REGISTRY_PORT ?= 5001
 
 cluster-up:
 	@if k3d registry list $(REGISTRY_NAME) >/dev/null 2>&1; then \

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ make deploy            # deploy ingest-service and CronJob
 make tilt              # start Tilt for live updates
 ```
 
+`make cluster-up` creates a local registry on port `5001` by default. Override with `REGISTRY_PORT` if needed.
+
 Start Metabase in a separate terminal:
 
 ```bash

--- a/Tiltfile
+++ b/Tiltfile
@@ -1,5 +1,6 @@
 CLUSTER_NAME = read_env("CLUSTER_NAME", "personal")
-default_registry("k3d-%s-registry:5000" % CLUSTER_NAME)
+REGISTRY_PORT = read_env("REGISTRY_PORT", "5001")
+default_registry("k3d-%s-registry:%s" % (CLUSTER_NAME, REGISTRY_PORT))
 
 def helm(name, chart, namespace='', values=[]):
     cmd = ['helm', 'template', name, chart]


### PR DESCRIPTION
## Summary
- default local registry to port 5001
- allow overriding the registry port in Tilt via `REGISTRY_PORT`
- document default registry port and how to change it

## Testing
- `make cluster-up` *(fails: k3d: command not found)*
- `make cluster-down` *(fails: k3d: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d6c8eb3888325bbbdd65a72a52c46