### PR TITLE
Fix environment variable handling in Tiltfile

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -1,5 +1,9 @@
-CLUSTER_NAME = read_env("CLUSTER_NAME", "personal")
-REGISTRY_PORT = read_env("REGISTRY_PORT", "5001")
+import os
+
+# Read environment variables for cluster configuration, falling back to
+# sensible defaults when they are not set.
+CLUSTER_NAME = os.environ.get("CLUSTER_NAME", "personal")
+REGISTRY_PORT = os.environ.get("REGISTRY_PORT", "5001")
 default_registry("k3d-%s-registry:%s" % (CLUSTER_NAME, REGISTRY_PORT))
 
 def helm(name, chart, namespace='', values=[]):


### PR DESCRIPTION
## Summary
- use `os.environ.get` for CLUSTER_NAME and REGISTRY_PORT defaults

## Testing
- `make tilt` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ec102db9c832583e3baa03245042d