### PR TITLE
Create namespace for platform chart

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -1,6 +1,7 @@
 # Read environment variables for cluster configuration, falling back to
 # sensible defaults when they are not set.
 CLUSTER_NAME = os.getenv("CLUSTER_NAME", "personal")
+NAMESPACE = os.getenv("NAMESPACE", "personal")
 REGISTRY_PORT = os.getenv("REGISTRY_PORT", "5001")
 default_registry("k3d-%s-registry:%s" % (CLUSTER_NAME, REGISTRY_PORT))
 
@@ -15,7 +16,7 @@ def helm(name, chart, namespace='', values=[]):
 helm_release = helm(
     name='platform',
     chart='charts/platform',
-    namespace='personal',
+    namespace=NAMESPACE,
     values=['charts/platform/values.yaml', 'charts/platform/values.local.sops.yaml'],
 )
 

--- a/charts/platform/values.yaml
+++ b/charts/platform/values.yaml
@@ -1,5 +1,5 @@
 namespace: personal
-namespaceCreate: false
+namespaceCreate: true
 
 postgresql:
   primary:


### PR DESCRIPTION
## Summary
- read namespace from `NAMESPACE` env var in Tiltfile
- enable automatic namespace creation in Helm values

## Testing
- `bash -x /tmp/get_helm.sh` *(failed: curl: (22) The requested URL returned error: 403)*

------
https://chatgpt.com/codex/tasks/task_e_689f53cf8ccc8325a67b752e982705ab