### PR TITLE
fix: correct postgres host for ingest service

### DIFF
--- a/charts/platform/templates/ingest-cronjob.yaml
+++ b/charts/platform/templates/ingest-cronjob.yaml
@@ -15,7 +15,7 @@ spec:
               args: ["--mode=scan", "--input=/incoming"]
               env:
                 - name: DB_URL
-                  value: {{ .Values.ingestService.env.DB_URL | quote }}
+                  value: {{ printf "jdbc:postgresql://%s-postgresql.%s.svc.cluster.local:5432/%s" .Release.Name .Values.namespace .Values.postgresql.auth.database | quote }}
                 - name: DB_USER
                   value: {{ .Values.ingestService.env.DB_USER | quote }}
                 - name: DB_PASSWORD

--- a/charts/platform/templates/ingest-deployment.yaml
+++ b/charts/platform/templates/ingest-deployment.yaml
@@ -20,7 +20,7 @@ spec:
           image: {{ .Values.ingestService.image }}
           env:
             - name: DB_URL
-              value: {{ .Values.ingestService.env.DB_URL | quote }}
+              value: {{ printf "jdbc:postgresql://%s-postgresql.%s.svc.cluster.local:5432/%s" .Release.Name .Values.namespace .Values.postgresql.auth.database | quote }}
             - name: DB_USER
               value: {{ .Values.ingestService.env.DB_USER | quote }}
             - name: DB_PASSWORD

--- a/charts/platform/values.yaml
+++ b/charts/platform/values.yaml
@@ -12,7 +12,6 @@ postgresql:
 ingestService:
   image: ingest-service:latest
   env:
-    DB_URL: jdbc:postgresql://postgresql.personal.svc.cluster.local:5432/personal
     DB_USER: user
     DB_PASSWORD: changeme
   schedule: "*/10 * * * *"


### PR DESCRIPTION
## Summary
- build Postgres JDBC URL from Helm release and namespace for ingest Deployment and CronJob
- remove hard-coded DB_URL from Helm values to avoid bad hostnames

## Testing
- `helm template platform charts/platform --namespace personal` *(fails: command not found: helm)*

------
https://chatgpt.com/codex/tasks/task_e_689faa2d95608325a4ab45b570e139b4