### PR TITLE
Support multiple transaction CSV formats

### DIFF
--- a/apps/ingest-service/src/main/java/com/example/ingest/CsvTransactionMapper.java
+++ b/apps/ingest-service/src/main/java/com/example/ingest/CsvTransactionMapper.java
@@ -6,41 +6,104 @@ import org.apache.commons.codec.digest.DigestUtils;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 public class CsvTransactionMapper {
     public List<Transaction> parse(Reader reader) throws IOException, CsvException {
+        return parse(reader, Map.of());
+    }
+
+    public List<Transaction> parse(Reader reader, Map<String, String> defaults) throws IOException, CsvException {
         try (CSVReader csv = new CSVReader(reader)) {
             List<String[]> rows = csv.readAll();
-            String[] header = rows.remove(0);
-            return rows.stream().map(r -> mapRow(header, r)).toList();
+            String[] rawHeader = rows.remove(0);
+            String[] header = Arrays.stream(rawHeader).map(this::normalize).toArray(String[]::new);
+            return rows.stream().map(r -> mapRow(header, r, defaults)).toList();
         }
     }
 
-    private Transaction mapRow(String[] header, String[] row) {
-        Map<String, String> m = new HashMap<>();
+    private Transaction mapRow(String[] header, String[] row, Map<String, String> defaults) {
+        Map<String, String> m = new HashMap<>(defaults);
         for (int i = 0; i < header.length && i < row.length; i++) {
             m.put(header[i], row[i]);
         }
         Transaction t = new Transaction();
-        t.accountId = m.get("account_id");
-        t.occurredAt = parseInstant(m.get("occurred_at"));
-        t.postedAt = parseInstant(m.get("posted_at"));
-        t.amountCents = Long.parseLong(m.get("amount_cents"));
-        t.currency = m.getOrDefault("currency", "USD");
-        t.merchant = m.get("merchant");
+        t.accountId = coalesce(m, "account_id", "card_no");
+        t.occurredAt = parseDate(coalesce(m, "occurred_at", "transaction_date"));
+        t.postedAt = parseDate(coalesce(m, "posted_at", "posted_date", "post_date"));
+        t.amountCents = parseAmount(m);
+        t.currency = m.getOrDefault("currency", defaults.getOrDefault("currency", "USD"));
+        t.merchant = coalesce(m, "merchant", "description");
         t.category = m.get("category");
+        t.type = m.get("type");
         t.memo = m.get("memo");
-        t.source = m.get("source");
+        t.source = m.getOrDefault("source", defaults.get("source"));
         t.rawJson = new com.fasterxml.jackson.databind.ObjectMapper().valueToTree(m).toString();
         t.hash = DigestUtils.sha256Hex(t.accountId + t.amountCents + t.occurredAt + t.merchant);
         return t;
     }
 
-    private Instant parseInstant(String v) {
-        return v == null || v.isBlank() ? null : Instant.parse(v);
+    private long parseAmount(Map<String, String> m) {
+        if (m.containsKey("amount_cents")) {
+            return Long.parseLong(m.get("amount_cents"));
+        }
+        if (m.containsKey("amount")) {
+            return toCents(new BigDecimal(m.get("amount")));
+        }
+        String credit = m.get("credit");
+        if (credit != null && !credit.isBlank()) {
+            return toCents(new BigDecimal(credit));
+        }
+        String debit = m.get("debit");
+        if (debit != null && !debit.isBlank()) {
+            return -toCents(new BigDecimal(debit));
+        }
+        return 0;
+    }
+
+    private long toCents(BigDecimal v) {
+        return v.movePointRight(2).setScale(0, RoundingMode.HALF_UP).longValue();
+    }
+
+    private Instant parseDate(String v) {
+        if (v == null || v.isBlank()) return null;
+        try {
+            return Instant.parse(v);
+        } catch (DateTimeParseException e) {
+            try {
+                LocalDate d = LocalDate.parse(v, DateTimeFormatter.ISO_DATE);
+                return d.atStartOfDay(ZoneOffset.UTC).toInstant();
+            } catch (DateTimeParseException e2) {
+                LocalDate d = LocalDate.parse(v, DateTimeFormatter.ofPattern("MM/dd/yyyy"));
+                return d.atStartOfDay(ZoneOffset.UTC).toInstant();
+            }
+        }
+    }
+
+    private String normalize(String h) {
+        return h.toLowerCase()
+                .replaceAll("[. ]", "_")
+                .replaceAll("_+", "_")
+                .replaceAll("^_|_$", "");
+    }
+
+    private String coalesce(Map<String, String> m, String... keys) {
+        for (String k : keys) {
+            String v = m.get(k);
+            if (v != null && !v.isBlank()) {
+                return v;
+            }
+        }
+        return null;
     }
 }

--- a/apps/ingest-service/src/main/java/com/example/ingest/IngestService.java
+++ b/apps/ingest-service/src/main/java/com/example/ingest/IngestService.java
@@ -47,6 +47,7 @@ public class IngestService {
                 .set(DSL.field("currency"), t.currency)
                 .set(DSL.field("merchant"), t.merchant)
                 .set(DSL.field("category"), t.category)
+                .set(DSL.field("txn_type"), t.type)
                 .set(DSL.field("memo"), t.memo)
                 .set(DSL.field("source"), t.source)
                 .set(DSL.field("hash"), t.hash)

--- a/apps/ingest-service/src/main/java/com/example/ingest/Transaction.java
+++ b/apps/ingest-service/src/main/java/com/example/ingest/Transaction.java
@@ -10,6 +10,7 @@ public class Transaction {
     public String currency;
     public String merchant;
     public String category;
+    public String type;
     public String memo;
     public String source;
     public String hash;

--- a/apps/ingest-service/src/test/java/com/example/ingest/CsvTransactionMapperTest.java
+++ b/apps/ingest-service/src/test/java/com/example/ingest/CsvTransactionMapperTest.java
@@ -3,7 +3,9 @@ package com.example.ingest;
 import org.junit.jupiter.api.Test;
 
 import java.io.StringReader;
+import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -13,12 +15,46 @@ class CsvTransactionMapperTest {
         String csv = "account_id,occurred_at,posted_at,amount_cents,currency,merchant,category,memo,source\n" +
                 "acct1,2024-01-01T10:00:00Z,2024-01-02T10:00:00Z,-5678,USD,Store B,Refund,Returned item,capitalone\n";
         CsvTransactionMapper mapper = new CsvTransactionMapper();
-        List<Transaction> txs = mapper.parse(new StringReader(csv));
+        List<Transaction> txs = mapper.parse(new StringReader(csv), Map.of());
         assertEquals(1, txs.size());
         Transaction t = txs.get(0);
         assertEquals("acct1", t.accountId);
         assertEquals(-5678, t.amountCents);
         assertEquals("Store B", t.merchant);
         assertNotNull(t.hash);
+    }
+
+    @Test
+    void parsesCapitalOneStyleCsv() throws Exception {
+        String csv = "Transaction Date,Posted Date,Card No.,Description,Category,Debit,Credit\n" +
+                "2025-04-30,2025-04-30,1828,CAPITAL ONE MOBILE PYMT,Payment/Credit,,600.00\n" +
+                "2025-04-28,2025-04-30,1828,TST*ROYAL BAKEHOUSE,Dining,14.12,\n";
+        CsvTransactionMapper mapper = new CsvTransactionMapper();
+        List<Transaction> txs = mapper.parse(new StringReader(csv), Map.of("source", "capitalone"));
+        assertEquals(2, txs.size());
+        Transaction t0 = txs.get(0);
+        assertEquals("1828", t0.accountId);
+        assertEquals(60000, t0.amountCents);
+        assertEquals(Instant.parse("2025-04-30T00:00:00Z"), t0.occurredAt);
+        Transaction t1 = txs.get(1);
+        assertEquals(-1412, t1.amountCents);
+        assertEquals("TST*ROYAL BAKEHOUSE", t1.merchant);
+    }
+
+    @Test
+    void parsesOtherInstitutionCsv() throws Exception {
+        String csv = "Transaction Date,Post Date,Description,Category,Type,Amount,Memo\n" +
+                "04/30/2025,04/30/2025,Payment Thank You-Mobile,,Payment,18.62,\n" +
+                "04/27/2025,04/29/2025,JetBrains Americas INC,Shopping,Sale,-18.62,\n";
+        CsvTransactionMapper mapper = new CsvTransactionMapper();
+        List<Transaction> txs = mapper.parse(new StringReader(csv), Map.of("account_id", "acct2", "source", "otherbank"));
+        assertEquals(2, txs.size());
+        Transaction t0 = txs.get(0);
+        assertEquals("acct2", t0.accountId);
+        assertEquals(1862, t0.amountCents);
+        assertEquals("Payment", t0.type);
+        Transaction t1 = txs.get(1);
+        assertEquals(-1862, t1.amountCents);
+        assertEquals("JetBrains Americas INC", t1.merchant);
     }
 }

--- a/ops/sql/V2__add_txn_type.sql
+++ b/ops/sql/V2__add_txn_type.sql
@@ -1,0 +1,1 @@
+ALTER TABLE transactions ADD COLUMN IF NOT EXISTS txn_type TEXT;


### PR DESCRIPTION
## Summary
- parse various bank CSV headers into canonical transactions
- track optional transaction type and add schema migration
- cover Capital One and alternate formats with tests

## Testing
- `gradle --console=plain test`

------
https://chatgpt.com/codex/tasks/task_e_689fafde77f48325ba369afb8626fbb4