### PR TITLE
Align DB password between Postgres and ingest

### DIFF
--- a/charts/platform/values.local.sops.yaml
+++ b/charts/platform/values.local.sops.yaml
@@ -1,5 +1,9 @@
 # Encrypted secrets for local development
 postgresql:
   auth:
-    username: ENC[AES256_GCM,data:abcd,iv:abcd,tag:abcd,type:str]
-    password: ENC[AES256_GCM,data:abcd,iv:abcd,tag:abcd,type:str]
+    username: &db_user ENC[AES256_GCM,data:abcd,iv:abcd,tag:abcd,type:str]
+    password: &db_password ENC[AES256_GCM,data:abcd,iv:abcd,tag:abcd,type:str]
+ingestService:
+  env:
+    DB_USER: *db_user
+    DB_PASSWORD: *db_password

--- a/charts/platform/values.yaml
+++ b/charts/platform/values.yaml
@@ -7,13 +7,14 @@ postgresql:
       enabled: false
   auth:
     username: user
+    password: &db_password changeme
     database: personal
 
 ingestService:
   image: ingest-service:latest
   env:
     DB_USER: user
-    DB_PASSWORD: changeme
+    DB_PASSWORD: *db_password
   schedule: "*/10 * * * *"
   hostPaths:
     incoming: /incoming


### PR DESCRIPTION
## Summary
- ensure Postgres and ingest-service use the same database password
- expose encrypted values for ingest-service to reuse Postgres credentials

## Testing
- `gradle test --no-daemon`
- `make build-app` *(fails: Failure: the server hosted at that remote is unavailable.)*

------
https://chatgpt.com/codex/tasks/task_e_689fb561735c83259723367b028f6378