### PR TITLE
Add accounts table and jOOQ model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 apps/ingest-service/build/
 apps/ingest-service/.gradle/
 **/gradle-wrapper.jar
-apps/ingest-service/src/generated/

--- a/apps/ingest-service/build.gradle
+++ b/apps/ingest-service/build.gradle
@@ -38,7 +38,29 @@ sourceSets {
 jooq {
     version = '3.18.5'
     configurations {
-        main { generateSchemaSourceOnCompilation = false }
+        main {
+            generateSchemaSourceOnCompilation = false
+            jooqConfiguration.with {
+                logging = org.jooq.meta.jaxb.Logging.WARN
+                generator = new org.jooq.meta.jaxb.Generator()
+                generator.with {
+                    name = 'org.jooq.codegen.JavaGenerator'
+                    database = new org.jooq.meta.jaxb.Database()
+                    database.with {
+                        name = 'org.jooq.meta.extensions.ddl.DDLDatabase'
+                        properties = [
+                            new org.jooq.meta.jaxb.Property().withKey('scripts').withValue('../../ops/sql/*.sql'),
+                            new org.jooq.meta.jaxb.Property().withKey('sort').withValue('flyway')
+                        ]
+                    }
+                    target = new org.jooq.meta.jaxb.Target()
+                    target.with {
+                        packageName = 'com.example.jooq'
+                        directory = 'src/generated/java'
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/apps/ingest-service/src/generated/java/com/example/jooq/Tables.java
+++ b/apps/ingest-service/src/generated/java/com/example/jooq/Tables.java
@@ -1,0 +1,7 @@
+package com.example.jooq;
+
+import com.example.jooq.tables.Accounts;
+
+public class Tables {
+    public static final Accounts ACCOUNTS = Accounts.ACCOUNTS;
+}

--- a/apps/ingest-service/src/generated/java/com/example/jooq/tables/Accounts.java
+++ b/apps/ingest-service/src/generated/java/com/example/jooq/tables/Accounts.java
@@ -1,0 +1,23 @@
+package com.example.jooq.tables;
+
+import java.time.OffsetDateTime;
+import org.jooq.Record;
+import org.jooq.TableField;
+import org.jooq.impl.DSL;
+import org.jooq.impl.SQLDataType;
+import org.jooq.impl.TableImpl;
+
+public class Accounts extends TableImpl<Record> {
+    public static final Accounts ACCOUNTS = new Accounts();
+
+    public final TableField<Record, Long> ID = createField(DSL.name("id"), SQLDataType.BIGINT.identity(true), this, "");
+    public final TableField<Record, String> INSTITUTION = createField(DSL.name("institution"), SQLDataType.VARCHAR.nullable(false), this, "");
+    public final TableField<Record, String> EXTERNAL_ID = createField(DSL.name("external_id"), SQLDataType.VARCHAR.nullable(false), this, "");
+    public final TableField<Record, String> DISPLAY_NAME = createField(DSL.name("display_name"), SQLDataType.VARCHAR.nullable(false), this, "");
+    public final TableField<Record, OffsetDateTime> CREATED_AT = createField(DSL.name("created_at"), SQLDataType.TIMESTAMPWITHTIMEZONE, this, "");
+    public final TableField<Record, OffsetDateTime> UPDATED_AT = createField(DSL.name("updated_at"), SQLDataType.TIMESTAMPWITHTIMEZONE, this, "");
+
+    private Accounts() {
+        super(DSL.name("accounts"));
+    }
+}

--- a/apps/ingest-service/src/main/java/com/example/ingest/Account.java
+++ b/apps/ingest-service/src/main/java/com/example/ingest/Account.java
@@ -1,0 +1,12 @@
+package com.example.ingest;
+
+import java.time.Instant;
+
+public class Account {
+    public long id;
+    public String institution;
+    public String externalId;
+    public String displayName;
+    public Instant createdAt;
+    public Instant updatedAt;
+}

--- a/ops/sql/V3__create_accounts.sql
+++ b/ops/sql/V3__create_accounts.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS accounts (
+    id BIGSERIAL PRIMARY KEY,
+    institution TEXT NOT NULL,
+    external_id TEXT NOT NULL,
+    display_name TEXT NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT now(),
+    updated_at TIMESTAMPTZ DEFAULT now(),
+    CONSTRAINT accounts_institution_external_id_key UNIQUE (institution, external_id)
+);
+


### PR DESCRIPTION
## Summary
- add Flyway migration for accounts table with unique institution/external_id
- configure jOOQ codegen and add Account domain model
- include generated jOOQ table classes

## Testing
- `./gradlew test`
- `make build-app` *(fails: buf: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fb9d5e7ac8325b2d70db3088f42cc