### PR TITLE
Use numeric account ids

### DIFF
--- a/apps/ingest-service/build.gradle
+++ b/apps/ingest-service/build.gradle
@@ -26,6 +26,9 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    // Needed for jOOQ's DDLDatabase integration
+    jooqGenerator 'org.jooq:jooq-meta-extensions:3.18.5'
 }
 
 sourceSets {

--- a/apps/ingest-service/src/generated/java/com/example/jooq/Tables.java
+++ b/apps/ingest-service/src/generated/java/com/example/jooq/Tables.java
@@ -1,7 +1,9 @@
 package com.example.jooq;
 
 import com.example.jooq.tables.Accounts;
+import com.example.jooq.tables.Transactions;
 
 public class Tables {
     public static final Accounts ACCOUNTS = Accounts.ACCOUNTS;
+    public static final Transactions TRANSACTIONS = Transactions.TRANSACTIONS;
 }

--- a/apps/ingest-service/src/generated/java/com/example/jooq/tables/Transactions.java
+++ b/apps/ingest-service/src/generated/java/com/example/jooq/tables/Transactions.java
@@ -1,0 +1,33 @@
+package com.example.jooq.tables;
+
+import java.time.OffsetDateTime;
+import org.jooq.JSONB;
+import org.jooq.Record;
+import org.jooq.TableField;
+import org.jooq.impl.DSL;
+import org.jooq.impl.SQLDataType;
+import org.jooq.impl.TableImpl;
+
+public class Transactions extends TableImpl<Record> {
+    public static final Transactions TRANSACTIONS = new Transactions();
+
+    public final TableField<Record, Long> ID = createField(DSL.name("id"), SQLDataType.BIGINT.identity(true), this, "");
+    public final TableField<Record, Long> ACCOUNT_ID = createField(DSL.name("account_id"), SQLDataType.BIGINT.nullable(false), this, "");
+    public final TableField<Record, OffsetDateTime> OCCURRED_AT = createField(DSL.name("occurred_at"), SQLDataType.TIMESTAMPWITHTIMEZONE, this, "");
+    public final TableField<Record, OffsetDateTime> POSTED_AT = createField(DSL.name("posted_at"), SQLDataType.TIMESTAMPWITHTIMEZONE, this, "");
+    public final TableField<Record, Long> AMOUNT_CENTS = createField(DSL.name("amount_cents"), SQLDataType.BIGINT.nullable(false), this, "");
+    public final TableField<Record, String> CURRENCY = createField(DSL.name("currency"), SQLDataType.VARCHAR.nullable(false), this, "");
+    public final TableField<Record, String> MERCHANT = createField(DSL.name("merchant"), SQLDataType.VARCHAR, this, "");
+    public final TableField<Record, String> CATEGORY = createField(DSL.name("category"), SQLDataType.VARCHAR, this, "");
+    public final TableField<Record, String> TXN_TYPE = createField(DSL.name("txn_type"), SQLDataType.VARCHAR, this, "");
+    public final TableField<Record, String> MEMO = createField(DSL.name("memo"), SQLDataType.VARCHAR, this, "");
+    public final TableField<Record, String> SOURCE = createField(DSL.name("source"), SQLDataType.VARCHAR.nullable(false), this, "");
+    public final TableField<Record, String> HASH = createField(DSL.name("hash"), SQLDataType.VARCHAR.nullable(false), this, "");
+    public final TableField<Record, JSONB> RAW_JSON = createField(DSL.name("raw_json"), SQLDataType.JSONB.nullable(false), this, "");
+    public final TableField<Record, OffsetDateTime> CREATED_AT = createField(DSL.name("created_at"), SQLDataType.TIMESTAMPWITHTIMEZONE, this, "");
+
+    private Transactions() {
+        super(DSL.name("transactions"));
+    }
+}
+

--- a/apps/ingest-service/src/main/java/com/example/ingest/CsvTransactionMapper.java
+++ b/apps/ingest-service/src/main/java/com/example/ingest/CsvTransactionMapper.java
@@ -38,7 +38,8 @@ public class CsvTransactionMapper {
             m.put(header[i], row[i]);
         }
         Transaction t = new Transaction();
-        t.accountId = coalesce(m, "account_id", "card_no");
+        String acct = coalesce(m, "account_id", "card_no");
+        t.accountId = acct == null ? 0L : Long.parseLong(acct);
         t.occurredAt = parseDate(coalesce(m, "occurred_at", "transaction_date"));
         t.postedAt = parseDate(coalesce(m, "posted_at", "posted_date", "post_date"));
         t.amountCents = parseAmount(m);
@@ -49,7 +50,8 @@ public class CsvTransactionMapper {
         t.memo = m.get("memo");
         t.source = m.getOrDefault("source", defaults.get("source"));
         t.rawJson = new com.fasterxml.jackson.databind.ObjectMapper().valueToTree(m).toString();
-        t.hash = DigestUtils.sha256Hex(t.accountId + t.amountCents + t.occurredAt + t.merchant);
+        String occurred = t.occurredAt == null ? "" : t.occurredAt.toString();
+        t.hash = DigestUtils.sha256Hex(t.accountId + t.amountCents + occurred + t.merchant);
         return t;
     }
 

--- a/apps/ingest-service/src/main/java/com/example/ingest/IngestService.java
+++ b/apps/ingest-service/src/main/java/com/example/ingest/IngestService.java
@@ -40,7 +40,7 @@ public class IngestService {
 
     private void upsert(Transaction t) {
         dsl.insertInto(DSL.table("transactions"))
-                .set(DSL.field("account_id"), t.accountId)
+                .set(DSL.field("account_id", Long.class), t.accountId)
                 .set(DSL.field("occurred_at"), toTs(t.occurredAt))
                 .set(DSL.field("posted_at"), toTs(t.postedAt))
                 .set(DSL.field("amount_cents"), t.amountCents)
@@ -52,7 +52,7 @@ public class IngestService {
                 .set(DSL.field("source"), t.source)
                 .set(DSL.field("hash"), t.hash)
                 .set(DSL.field("raw_json"), DSL.field("?::jsonb", String.class, t.rawJson))
-                .onConflict(DSL.field("account_id"), DSL.field("hash"))
+                .onConflict(DSL.field("account_id", Long.class), DSL.field("hash"))
                 .doNothing()
                 .execute();
     }

--- a/apps/ingest-service/src/main/java/com/example/ingest/Transaction.java
+++ b/apps/ingest-service/src/main/java/com/example/ingest/Transaction.java
@@ -3,7 +3,7 @@ package com.example.ingest;
 import java.time.Instant;
 
 public class Transaction {
-    public String accountId;
+    public long accountId;
     public Instant occurredAt;
     public Instant postedAt;
     public long amountCents;

--- a/apps/ingest-service/src/test/java/com/example/ingest/CsvTransactionMapperTest.java
+++ b/apps/ingest-service/src/test/java/com/example/ingest/CsvTransactionMapperTest.java
@@ -13,12 +13,12 @@ class CsvTransactionMapperTest {
     @Test
     void parsesCsv() throws Exception {
         String csv = "account_id,occurred_at,posted_at,amount_cents,currency,merchant,category,memo,source\n" +
-                "acct1,2024-01-01T10:00:00Z,2024-01-02T10:00:00Z,-5678,USD,Store B,Refund,Returned item,capitalone\n";
+                "1,2024-01-01T10:00:00Z,2024-01-02T10:00:00Z,-5678,USD,Store B,Refund,Returned item,capitalone\n";
         CsvTransactionMapper mapper = new CsvTransactionMapper();
         List<Transaction> txs = mapper.parse(new StringReader(csv), Map.of());
         assertEquals(1, txs.size());
         Transaction t = txs.get(0);
-        assertEquals("acct1", t.accountId);
+        assertEquals(1L, t.accountId);
         assertEquals(-5678, t.amountCents);
         assertEquals("Store B", t.merchant);
         assertNotNull(t.hash);
@@ -33,7 +33,7 @@ class CsvTransactionMapperTest {
         List<Transaction> txs = mapper.parse(new StringReader(csv), Map.of("source", "capitalone"));
         assertEquals(2, txs.size());
         Transaction t0 = txs.get(0);
-        assertEquals("1828", t0.accountId);
+        assertEquals(1828L, t0.accountId);
         assertEquals(60000, t0.amountCents);
         assertEquals(Instant.parse("2025-04-30T00:00:00Z"), t0.occurredAt);
         Transaction t1 = txs.get(1);
@@ -47,10 +47,10 @@ class CsvTransactionMapperTest {
                 "04/30/2025,04/30/2025,Payment Thank You-Mobile,,Payment,18.62,\n" +
                 "04/27/2025,04/29/2025,JetBrains Americas INC,Shopping,Sale,-18.62,\n";
         CsvTransactionMapper mapper = new CsvTransactionMapper();
-        List<Transaction> txs = mapper.parse(new StringReader(csv), Map.of("account_id", "acct2", "source", "otherbank"));
+        List<Transaction> txs = mapper.parse(new StringReader(csv), Map.of("account_id", "2", "source", "otherbank"));
         assertEquals(2, txs.size());
         Transaction t0 = txs.get(0);
-        assertEquals("acct2", t0.accountId);
+        assertEquals(2L, t0.accountId);
         assertEquals(1862, t0.amountCents);
         assertEquals("Payment", t0.type);
         Transaction t1 = txs.get(1);

--- a/ops/sql/V4__transactions_account_fk.sql
+++ b/ops/sql/V4__transactions_account_fk.sql
@@ -1,0 +1,18 @@
+ALTER TABLE transactions DROP CONSTRAINT IF EXISTS transactions_account_id_fkey;
+DROP INDEX IF EXISTS transactions_account_hash_idx;
+
+ALTER TABLE transactions ADD COLUMN account_id_new BIGINT;
+UPDATE transactions t
+SET account_id_new = a.id
+FROM accounts a
+WHERE a.external_id = t.account_id AND a.institution = t.source;
+
+ALTER TABLE transactions DROP COLUMN account_id;
+ALTER TABLE transactions RENAME COLUMN account_id_new TO account_id;
+
+ALTER TABLE transactions
+    ALTER COLUMN account_id SET NOT NULL,
+    ADD CONSTRAINT transactions_account_id_fkey FOREIGN KEY (account_id) REFERENCES accounts(id);
+
+CREATE UNIQUE INDEX transactions_account_hash_idx
+    ON transactions(account_id, hash);

--- a/storage/incoming/sample.csv
+++ b/storage/incoming/sample.csv
@@ -1,3 +1,3 @@
 account_id,occurred_at,posted_at,amount_cents,currency,merchant,category,memo,source
-acct1,2024-01-01T10:00:00Z,2024-01-02T10:00:00Z,1234,USD,Store A,Groceries,Weekly shopping,capitalone
-acct1,2024-01-03T10:00:00Z,2024-01-04T10:00:00Z,-5678,USD,Store B,Refund,Returned item,capitalone
+1,2024-01-01T10:00:00Z,2024-01-02T10:00:00Z,1234,USD,Store A,Groceries,Weekly shopping,capitalone
+1,2024-01-03T10:00:00Z,2024-01-04T10:00:00Z,-5678,USD,Store B,Refund,Returned item,capitalone


### PR DESCRIPTION
## Summary
- migrate transactions.account_id from text to bigint and backfill using accounts table
- update ingest models and upsert logic to use numeric account ids
- regenerate jOOQ classes and sample data for bigint account ids

## Testing
- `cd apps/ingest-service && gradle generateJooq` (warnings only)
- `cd apps/ingest-service && gradle test`
- `make build-app` *(fails: Failure: the server hosted at that remote is unavailable.)*

------
https://chatgpt.com/codex/tasks/task_e_689fbccbf95483258e2b8da36cb4b90a