### PR TITLE
Add account resolver for ingest service

### DIFF
--- a/apps/ingest-service/build.gradle
+++ b/apps/ingest-service/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'com.h2database:h2:2.2.224'
 }
 
 sourceSets {

--- a/apps/ingest-service/src/main/java/com/example/ingest/AccountResolver.java
+++ b/apps/ingest-service/src/main/java/com/example/ingest/AccountResolver.java
@@ -1,0 +1,90 @@
+package com.example.ingest;
+
+import com.example.jooq.tables.Accounts;
+import org.jooq.DSLContext;
+import org.jooq.Record1;
+import org.springframework.stereotype.Component;
+
+import java.nio.file.Path;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+@Component
+public class AccountResolver {
+    private static final Pattern FILE_PATTERN = Pattern.compile("([A-Za-z0-9]+)[-_]([A-Za-z0-9]+)");
+    private final DSLContext dsl;
+
+    public AccountResolver(DSLContext dsl) {
+        this.dsl = dsl;
+    }
+
+    public long resolve(List<Transaction> txs, Path file) {
+        String source = uniqueValue(
+                txs.stream().map(t -> t.source).filter(Objects::nonNull).filter(s -> !s.isBlank()).collect(Collectors.toList()),
+                "source");
+        String external = uniqueValue(
+                txs.stream().map(t -> t.accountId).filter(Objects::nonNull).filter(s -> !s.isBlank()).collect(Collectors.toList()),
+                "account");
+
+        String fileSource = null;
+        String fileExternal = null;
+        if (file != null) {
+            Matcher m = FILE_PATTERN.matcher(file.getFileName().toString());
+            if (m.find()) {
+                fileSource = m.group(1);
+                fileExternal = m.group(2);
+            }
+        }
+
+        if (source == null) {
+            source = fileSource;
+        } else if (fileSource != null && !fileSource.equals(source)) {
+            throw new IllegalArgumentException("Ambiguous source identifiers");
+        }
+
+        if (external == null) {
+            external = fileExternal;
+        } else if (fileExternal != null && !fileExternal.equals(external)) {
+            throw new IllegalArgumentException("Ambiguous account identifiers");
+        }
+
+        if (source == null || external == null) {
+            throw new IllegalArgumentException("Missing account identifiers");
+        }
+
+        Record1<Long> existing = dsl.select(Accounts.ACCOUNTS.ID)
+                .from(Accounts.ACCOUNTS)
+                .where(Accounts.ACCOUNTS.INSTITUTION.eq(source)
+                        .and(Accounts.ACCOUNTS.EXTERNAL_ID.eq(external)))
+                .fetchOne();
+        if (existing != null) {
+            return existing.value1();
+        }
+
+        OffsetDateTime now = OffsetDateTime.now();
+        return dsl.insertInto(Accounts.ACCOUNTS)
+                .set(Accounts.ACCOUNTS.INSTITUTION, source)
+                .set(Accounts.ACCOUNTS.EXTERNAL_ID, external)
+                .set(Accounts.ACCOUNTS.DISPLAY_NAME, external)
+                .set(Accounts.ACCOUNTS.CREATED_AT, now)
+                .set(Accounts.ACCOUNTS.UPDATED_AT, now)
+                .returning(Accounts.ACCOUNTS.ID)
+                .fetchOne()
+                .get(Accounts.ACCOUNTS.ID);
+    }
+
+    private String uniqueValue(List<String> values, String field) {
+        if (values.isEmpty()) return null;
+        String first = values.get(0);
+        for (String v : values) {
+            if (!first.equals(v)) {
+                throw new IllegalArgumentException("Ambiguous " + field + " identifiers");
+            }
+        }
+        return first;
+    }
+}

--- a/apps/ingest-service/src/main/java/com/example/ingest/IngestService.java
+++ b/apps/ingest-service/src/main/java/com/example/ingest/IngestService.java
@@ -14,10 +14,13 @@ import java.util.List;
 @Service
 public class IngestService {
     private final DSLContext dsl;
-    private final CsvTransactionMapper mapper = new CsvTransactionMapper();
+    private final AccountResolver accountResolver;
+    private final CsvTransactionMapper mapper;
 
-    public IngestService(DSLContext dsl) {
+    public IngestService(DSLContext dsl, AccountResolver accountResolver) {
         this.dsl = dsl;
+        this.accountResolver = accountResolver;
+        this.mapper = new CsvTransactionMapper(accountResolver);
     }
 
     public void scanAndIngest(Path input) throws IOException, com.opencsv.exceptions.CsvException {
@@ -33,14 +36,14 @@ public class IngestService {
 
     public void ingestFile(Path file) throws IOException, com.opencsv.exceptions.CsvException {
         try (Reader reader = Files.newBufferedReader(file)) {
-            List<Transaction> txs = mapper.parse(reader);
+            List<Transaction> txs = mapper.parse(file, reader);
             txs.forEach(this::upsert);
         }
     }
 
     private void upsert(Transaction t) {
         dsl.insertInto(DSL.table("transactions"))
-                .set(DSL.field("account_id"), t.accountId)
+                .set(DSL.field("account_id"), t.accountPk)
                 .set(DSL.field("occurred_at"), toTs(t.occurredAt))
                 .set(DSL.field("posted_at"), toTs(t.postedAt))
                 .set(DSL.field("amount_cents"), t.amountCents)

--- a/apps/ingest-service/src/main/java/com/example/ingest/Transaction.java
+++ b/apps/ingest-service/src/main/java/com/example/ingest/Transaction.java
@@ -4,6 +4,7 @@ import java.time.Instant;
 
 public class Transaction {
     public String accountId;
+    public Long accountPk;
     public Instant occurredAt;
     public Instant postedAt;
     public long amountCents;

--- a/apps/ingest-service/src/test/java/com/example/ingest/AccountResolverTest.java
+++ b/apps/ingest-service/src/test/java/com/example/ingest/AccountResolverTest.java
@@ -1,0 +1,51 @@
+package com.example.ingest;
+
+import org.jooq.DSLContext;
+import org.jooq.impl.DSL;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class AccountResolverTest {
+    private DSLContext initDsl() {
+        DSLContext dsl = DSL.using("jdbc:h2:mem:test;MODE=PostgreSQL;DATABASE_TO_UPPER=false", "sa", "");
+        dsl.execute("drop table if exists accounts");
+        dsl.execute("create table accounts (id serial primary key, institution varchar not null, external_id varchar not null, display_name varchar not null, created_at timestamp, updated_at timestamp)");
+        dsl.execute("create unique index on accounts(institution, external_id)");
+        return dsl;
+    }
+
+    @Test
+    void insertsWhenMissing() {
+        DSLContext dsl = initDsl();
+        AccountResolver resolver = new AccountResolver(dsl);
+        Transaction t = new Transaction();
+        t.accountId = "1234";
+        t.source = "bank";
+        long id1 = resolver.resolve(List.of(t), Path.of("bank-1234.csv"));
+        long id2 = resolver.resolve(List.of(t), Path.of("bank-1234.csv"));
+        assertEquals(id1, id2);
+    }
+
+    @Test
+    void throwsOnAmbiguousAccount() {
+        DSLContext dsl = initDsl();
+        AccountResolver resolver = new AccountResolver(dsl);
+        Transaction t1 = new Transaction();
+        t1.accountId = "1111";
+        Transaction t2 = new Transaction();
+        t2.accountId = "2222";
+        assertThrows(IllegalArgumentException.class, () -> resolver.resolve(List.of(t1, t2), Path.of("bank-1111.csv")));
+    }
+
+    @Test
+    void throwsOnMissingIdentifiers() {
+        DSLContext dsl = initDsl();
+        AccountResolver resolver = new AccountResolver(dsl);
+        Transaction t = new Transaction();
+        assertThrows(IllegalArgumentException.class, () -> resolver.resolve(List.of(t), Path.of("unknown.csv")));
+    }
+}


### PR DESCRIPTION
## Summary
- resolve accounts via new AccountResolver inserting missing entries
- set transaction account_id using resolver in mapper and service
- add tests for account resolution edge cases

## Testing
- `cd apps/ingest-service && ./gradlew test`
- `make build-app` *(fails: Failure: the server hosted at that remote is unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_689fc0fbc7b48325b9dacc8adc9304d1