### PR TITLE
Add Metabase helper target and docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,4 +43,16 @@ deploy:
 tilt:
 	tilt up
 
-.PHONY: cluster-up cluster-down clean deps install-core build-app deploy tilt
+metabase:
+	kubectl port-forward svc/platform-postgresql 5432:5432 -n $(NAMESPACE) &
+	docker rm -f metabase || true
+	docker run -d -p 8080:3000 --name metabase \
+		-e MB_DB_TYPE=postgres \
+		-e MB_DB_DBNAME=$(NAMESPACE) \
+		-e MB_DB_PORT=5432 \
+		-e MB_DB_USER=user \
+		-e MB_DB_PASS=changeme \
+		-e MB_DB_HOST=host.docker.internal \
+		metabase/metabase
+
+.PHONY: cluster-up cluster-down clean deps install-core build-app deploy tilt metabase

--- a/README.md
+++ b/README.md
@@ -36,16 +36,10 @@ Tilt rebuilds the ingest-service image and applies Kubernetes updates as source 
 Start Metabase in a separate terminal:
 
 ```bash
-kubectl port-forward svc/platform-postgresql 5432:5432 -n personal &
-docker run -d -p 8080:3000 --name metabase \
-  -e MB_DB_TYPE=postgres \
-  -e MB_DB_DBNAME=personal \
-  -e MB_DB_PORT=5432 \
-  -e MB_DB_USER=user \
-  -e MB_DB_PASS=changeme \
-  -e MB_DB_HOST=host.docker.internal \
-  metabase/metabase
+make metabase
 ```
+
+This forwards PostgreSQL to your host and launches a Metabase container preconfigured to use it.
 
 ## Data Ingestion
 


### PR DESCRIPTION
## Summary
- add `metabase` make target to port-forward Postgres and run Metabase container
- document `make metabase` in README

## Testing
- `cd apps/ingest-service && ./gradlew test`
- `make build-app` *(fails: Failure: the server hosted at that remote is unavailable.)*
- `make deps` *(fails: helm: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fd3663f9c8325a7aa80bfdec5f3ff