### PR TITLE
refactor: externalize db credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 apps/ingest-service/build/
 apps/ingest-service/.gradle/
 **/gradle-wrapper.jar
+charts/platform/values.local.yaml

--- a/charts/platform/templates/ingest-secret.yaml
+++ b/charts/platform/templates/ingest-secret.yaml
@@ -4,4 +4,5 @@ metadata:
   name: ingest-db
   namespace: {{ .Values.namespace }}
 stringData:
-  password: {{ .Values.ingestService.env.DB_PASSWORD | quote }}
+  username: {{ .Values.secrets.db.username | quote }}
+  password: {{ .Values.secrets.db.password | quote }}

--- a/charts/platform/values.local.sops.yaml
+++ b/charts/platform/values.local.sops.yaml
@@ -1,9 +1,32 @@
-# Encrypted secrets for local development
+#ENC[AES256_GCM,data:3OoauRGprxlwcQ+5EPUJ42QhEb2/l8iUNKi3H0ild3FetaFGJ1MFbQ==,iv:WKfUjT9LLS4d6+d5zbqlefMfx+RXAdSZvZeMslk8Vxk=,tag:OqDSR61NTYy77QI8lIRKGw==,type:comment]
+secrets:
+    db:
+        username: ENC[AES256_GCM,data:XJHGJ0p7K4Om,iv:b/R5rGiwrTuJYmmLHgpoMufiiQharf5t8MEbi74wvpc=,tag:rx+K5SbI4Z5LQCJa3m/Vwg==,type:str]
+        password: ENC[AES256_GCM,data:vh2yreJRXkTf,iv:grrdxNr+tC7qHqHnaYS6G4iwItVVVfI38Mhd22NMSBw=,tag:mIwZ1p4Gff6SKtbdGKH67g==,type:str]
 postgresql:
-  auth:
-    username: &db_user ENC[AES256_GCM,data:abcd,iv:abcd,tag:abcd,type:str]
-    password: &db_password ENC[AES256_GCM,data:abcd,iv:abcd,tag:abcd,type:str]
+    auth:
+        username: ENC[AES256_GCM,data:AQp4nI/n0bu5,iv:9uC50BL59Uob7/CQnk2LfVQhzGQols7RtN5UZBO2xcs=,tag:PifXHDxbMYjG92+tw1rRhA==,type:str]
+        password: ENC[AES256_GCM,data:CS2xCuFA9YWz,iv:X6nRHv5yCUljr78jx1bSwupGAu9G7sjnCK23pOftn34=,tag:8Dd0pRE/+GyQTJjCFNtyTQ==,type:str]
 ingestService:
-  env:
-    DB_USER: *db_user
-    DB_PASSWORD: *db_password
+    env:
+        DB_USER: ENC[AES256_GCM,data:Nu+jypZsDRuU,iv:Xjaa9J2b1mCDPi0m2Nv85t+TGPg0CyqnYM1AqFHS7kU=,tag:0IhqU6h0gV2uGtCZMVK9gg==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age196m57xyg39ymju254dzhshfxkvjsezr2g476zyfkd6d34ya0tscsv9gmvk
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAwbVNuNEROVlhpQ3VVY2Y2
+            eVhtMnpwdDZRUWFvaitQMkNwTXBuUXBuNXgwCk9ObUFGQ01wSnBJUC9naWNxSW81
+            OWxMWDhqRzdxcVNOM3FjNzZ4RER0a2cKLS0tIGtDL2xtTG1kZDJXWHdyNUd2MDZV
+            ZXdueW5rbVhCeGpIQjdMNDVLQVRHc2cK5AWjRtTTYcZ2SPWBI8y2Gw26anj8LeXx
+            GBNz/WYtgXGA+9Fc8POFQDSv1GvKAtA1ID2x90EuXMQFja1+Loc3eA==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2025-08-18T18:08:20Z"
+    mac: ENC[AES256_GCM,data:oJWFJq5XRFoKYKz5lhRCCB8O0yzJgTuvaLhFWfGXMYJWdyUSNG5cZSA4psxmJBZeHSbjAxVnwQ/Hv30YPIc6nk4wEsbYH8wt2cp1zgAJrpVRoIZF1KrdphHM/5J9uWC07vx4Y05lX23BMEoi8pSF+oYF82sgxf0TL1p2naGlsf0=,iv:Cxli/QNL+OujMT+jhuIn/amcL0/qC0fHjLNxaPDWToE=,tag:vISw2g/EBSXf8bq8duzZaw==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.8.1

--- a/charts/platform/values.yaml
+++ b/charts/platform/values.yaml
@@ -1,20 +1,24 @@
 namespace: personal
 namespaceCreate: true
 
+secrets:
+  db:
+    username: &db_user ""
+    password: &db_password ""
+
 postgresql:
   primary:
     persistence:
       enabled: false
   auth:
-    username: user
-    password: &db_password changeme
+    username: *db_user
+    password: *db_password
     database: personal
 
 ingestService:
   image: ingest-service:latest
   env:
-    DB_USER: user
-    DB_PASSWORD: *db_password
+    DB_USER: *db_user
   schedule: "*/10 * * * *"
   hostPaths:
     incoming: /incoming


### PR DESCRIPTION
## Summary
- strip hard-coded DB credentials from platform chart values
- reference encrypted secrets for ingest service password
- add SOPS-encrypted local values file and ignore decrypted copy

## Testing
- `cd apps/ingest-service && ./gradlew test`
- `make build-app` *(fails: buf: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a36b0dba208325bee97245df4421b7