### PR TITLE
docs: add SOPS usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,20 @@ Tilt rebuilds the ingest-service image and applies Kubernetes updates as source 
 
 ## Secrets
 Secrets live in SOPS-encrypted files under `charts/platform/*.sops.yaml`.
-To edit:
-```bash
-sops charts/platform/values.local.sops.yaml
-```
+### Secrets with SOPS
+
+- Generate an age key:
+  ```bash
+  age-keygen -o ~/.config/sops/age/keys.txt
+  ```
+- Store the key at `~/.config/sops/age/keys.txt`.
+- Edit encrypted files:
+  ```bash
+  sops charts/platform/values.local.sops.yaml
+  ```
+- Rotate or add recipients by updating `.sops.yaml`.
+
+`.sops.yaml` contains placeholder values—replace the example key with your own age public key. Add decrypted files (like `charts/platform/values.local.yaml`) to `.gitignore` to keep plaintext secrets out of version control.
 
 ## Cleanup
 ```bash


### PR DESCRIPTION
## Summary
- document generating and storing Age keys
- explain editing encrypted values and managing recipients
- note placeholder `.sops.yaml` key and ignoring decrypted files

## Testing
- `cd apps/ingest-service && ./gradlew test` *(fails: Unable to access jarfile)*
- `make deps` *(fails: helm: command not found)*
- `make build-app` *(fails: buf: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a36e045ed0832597f86ba56ee45928