### PR TITLE
chore: upgrade to Java 21

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A minimal personal data platform running on a local k3d Kubernetes cluster. It p
 - Helm (e.g., `brew install helm` or https://helm.sh/docs/intro/install/)
 - Tilt (e.g., `brew install tilt` or https://docs.tilt.dev/install.html)
 - age + SOPS (e.g., `brew install age sops` or https://github.com/mozilla/sops#installation)
-- Java 21 + Gradle (e.g., `brew install openjdk@21 gradle` or https://adoptium.net/)
+- Java 21 (JDK) + Gradle (e.g., `brew install openjdk@21 gradle` or https://adoptium.net/)
 - buf (installed via `make deps`)
 
 ## Quickstart

--- a/apps/ingest-service/build.gradle
+++ b/apps/ingest-service/build.gradle
@@ -7,7 +7,8 @@ plugins {
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'
-java.sourceCompatibility = JavaVersion.VERSION_17
+java.sourceCompatibility = JavaVersion.VERSION_21
+java.targetCompatibility = JavaVersion.VERSION_21
 
 repositories {
     mavenCentral()
@@ -66,6 +67,10 @@ jooq {
             }
         }
     }
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.release = 21
 }
 
 tasks.withType(Test) {


### PR DESCRIPTION
## Summary
- set ingest-service to compile against Java 21
- document Java 21 JDK requirement in the README

## Testing
- `gradle wrapper --gradle-version 8.4`
- `cd apps/ingest-service && ./gradlew test`
- `go install github.com/bufbuild/buf/cmd/buf@latest`
- `make build-app` *(fails: the server hosted at that remote is unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68a370202b34832580a2536cd0c3ea55