### PR TITLE
Add Teller API client with token and client-cert support

### DIFF
--- a/apps/teller-poller/src/main/java/com/example/teller/HttpTellerApi.java
+++ b/apps/teller-poller/src/main/java/com/example/teller/HttpTellerApi.java
@@ -1,0 +1,46 @@
+package com.example.teller;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpRequest;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * HTTP implementation of {@link TellerApi}.
+ */
+public final class HttpTellerApi implements TellerApi {
+
+    private final RequestExecutor executor;
+    private final URI baseUri = URI.create("https://api.teller.io");
+
+    public HttpTellerApi(RequestExecutor executor) {
+        this.executor = executor;
+    }
+
+    @Override
+    public JsonNode listAccounts(String token) throws IOException, InterruptedException {
+        HttpRequest request = HttpRequest.newBuilder(baseUri.resolve("/accounts"))
+            .header("Authorization", "Bearer " + token)
+            .GET()
+            .build();
+        return executor.execute(request);
+    }
+
+    @Override
+    public JsonNode listTransactions(String token, String accountId, String cursor)
+        throws IOException, InterruptedException {
+        String path = "/accounts/" + accountId + "/transactions";
+        if (cursor != null && !cursor.isBlank()) {
+            path += "?cursor=" + URLEncoder.encode(cursor, StandardCharsets.UTF_8);
+        }
+        HttpRequest request = HttpRequest.newBuilder(baseUri.resolve(path))
+            .header("Authorization", "Bearer " + token)
+            .GET()
+            .build();
+        return executor.execute(request);
+    }
+}
+

--- a/apps/teller-poller/src/main/java/com/example/teller/MtlsHttpClientFactory.java
+++ b/apps/teller-poller/src/main/java/com/example/teller/MtlsHttpClientFactory.java
@@ -1,0 +1,83 @@
+package com.example.teller;
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.http.HttpClient;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.GeneralSecurityException;
+import java.security.KeyFactory;
+import java.security.KeyStore;
+import java.security.PrivateKey;
+import java.security.SecureRandom;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.time.Duration;
+import java.util.Base64;
+
+/**
+ * Builds an {@link HttpClient} configured for mutual TLS using the provided certificate and key.
+ */
+public final class MtlsHttpClientFactory {
+
+    private final Path certPath;
+    private final Path keyPath;
+
+    public MtlsHttpClientFactory(Path certPath, Path keyPath) {
+        this.certPath = certPath;
+        this.keyPath = keyPath;
+    }
+
+    public HttpClient create() {
+        try {
+            CertificateFactory cf = CertificateFactory.getInstance("X.509");
+            X509Certificate cert;
+            try (InputStream certStream = Files.newInputStream(certPath)) {
+                cert = (X509Certificate) cf.generateCertificate(certStream);
+            }
+
+            String keyPem = Files.readString(keyPath)
+                .replace("-----BEGIN PRIVATE KEY-----", "")
+                .replace("-----END PRIVATE KEY-----", "")
+                .replaceAll("\\s", "");
+            byte[] keyBytes = Base64.getDecoder().decode(keyPem);
+            PrivateKey key = loadPrivateKey(keyBytes);
+
+            KeyStore keyStore = KeyStore.getInstance("PKCS12");
+            keyStore.load(null, null);
+            keyStore.setKeyEntry("teller", key, new char[0], new Certificate[]{cert});
+
+            KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+            kmf.init(keyStore, new char[0]);
+
+            TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+            tmf.init((KeyStore) null);
+
+            SSLContext sslContext = SSLContext.getInstance("TLS");
+            sslContext.init(kmf.getKeyManagers(), tmf.getTrustManagers(), new SecureRandom());
+
+            return HttpClient.newBuilder()
+                .sslContext(sslContext)
+                .connectTimeout(Duration.ofSeconds(10))
+                .build();
+        } catch (IOException | GeneralSecurityException e) {
+            throw new IllegalStateException("Failed to set up TLS client authentication", e);
+        }
+    }
+
+    private PrivateKey loadPrivateKey(byte[] keyBytes) throws GeneralSecurityException {
+        PKCS8EncodedKeySpec spec = new PKCS8EncodedKeySpec(keyBytes);
+        try {
+            return KeyFactory.getInstance("RSA").generatePrivate(spec);
+        } catch (InvalidKeySpecException e) {
+            return KeyFactory.getInstance("EC").generatePrivate(spec);
+        }
+    }
+}
+

--- a/apps/teller-poller/src/main/java/com/example/teller/RequestExecutor.java
+++ b/apps/teller-poller/src/main/java/com/example/teller/RequestExecutor.java
@@ -1,0 +1,15 @@
+package com.example.teller;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.io.IOException;
+import java.net.http.HttpRequest;
+
+/**
+ * Executes HTTP requests and returns parsed JSON responses.
+ */
+public interface RequestExecutor {
+
+    JsonNode execute(HttpRequest request) throws IOException, InterruptedException;
+}
+

--- a/apps/teller-poller/src/main/java/com/example/teller/RetryingRequestExecutor.java
+++ b/apps/teller-poller/src/main/java/com/example/teller/RetryingRequestExecutor.java
@@ -1,0 +1,51 @@
+package com.example.teller;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+/**
+ * Sends HTTP requests with simple retry/backoff behaviour and parses JSON responses.
+ */
+public final class RetryingRequestExecutor implements RequestExecutor {
+
+    private final HttpClient httpClient;
+    private final ObjectMapper mapper;
+    private final int maxAttempts;
+
+    public RetryingRequestExecutor(HttpClient httpClient, ObjectMapper mapper) {
+        this(httpClient, mapper, 3);
+    }
+
+    public RetryingRequestExecutor(HttpClient httpClient, ObjectMapper mapper, int maxAttempts) {
+        this.httpClient = httpClient;
+        this.mapper = mapper;
+        this.maxAttempts = maxAttempts;
+    }
+
+    @Override
+    public JsonNode execute(HttpRequest request) throws IOException, InterruptedException {
+        int attempts = 0;
+        while (true) {
+            attempts++;
+            try {
+                HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+                if (response.statusCode() >= 200 && response.statusCode() < 300) {
+                    return mapper.readTree(response.body());
+                }
+                throw new IOException("API error: " + response.statusCode() + " " + response.body());
+            } catch (IOException | InterruptedException e) {
+                if (attempts >= maxAttempts) {
+                    throw e;
+                }
+                long backoffMillis = (long) Math.pow(2, attempts - 1) * 1000L;
+                Thread.sleep(backoffMillis);
+            }
+        }
+    }
+}
+

--- a/apps/teller-poller/src/main/java/com/example/teller/TellerApi.java
+++ b/apps/teller-poller/src/main/java/com/example/teller/TellerApi.java
@@ -1,0 +1,17 @@
+package com.example.teller;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.io.IOException;
+
+/**
+ * Operations exposed by the Teller API.
+ */
+public interface TellerApi {
+
+    JsonNode listAccounts(String token) throws IOException, InterruptedException;
+
+    JsonNode listTransactions(String token, String accountId, String cursor)
+        throws IOException, InterruptedException;
+}
+

--- a/apps/teller-poller/src/main/java/com/example/teller/TellerClient.java
+++ b/apps/teller-poller/src/main/java/com/example/teller/TellerClient.java
@@ -1,0 +1,36 @@
+package com.example.teller;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * High-level client for interacting with the Teller API.
+ */
+@Component
+public final class TellerClient {
+
+    private final List<String> tokens;
+    private final TellerApi api;
+
+    public TellerClient(List<String> tokens, TellerApi api) {
+        this.tokens = List.copyOf(tokens);
+        this.api = api;
+    }
+
+    public JsonNode listAccounts(String token) throws IOException, InterruptedException {
+        return api.listAccounts(token);
+    }
+
+    public JsonNode listTransactions(String token, String accountId, String cursor)
+        throws IOException, InterruptedException {
+        return api.listTransactions(token, accountId, cursor);
+    }
+
+    public List<String> getTokens() {
+        return tokens;
+    }
+}
+

--- a/apps/teller-poller/src/main/java/com/example/teller/TellerClientFactory.java
+++ b/apps/teller-poller/src/main/java/com/example/teller/TellerClientFactory.java
@@ -1,0 +1,28 @@
+package com.example.teller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Assembles a {@link TellerClient} with the necessary HTTP and retry components.
+ */
+public final class TellerClientFactory {
+
+    private final Path certPath;
+    private final Path keyPath;
+
+    public TellerClientFactory(Path certPath, Path keyPath) {
+        this.certPath = certPath;
+        this.keyPath = keyPath;
+    }
+
+    public TellerClient create(List<String> tokens) {
+        MtlsHttpClientFactory httpClientFactory = new MtlsHttpClientFactory(certPath, keyPath);
+        RequestExecutor executor = new RetryingRequestExecutor(httpClientFactory.create(), new ObjectMapper());
+        TellerApi api = new HttpTellerApi(executor);
+        return new TellerClient(tokens, api);
+    }
+}
+

--- a/apps/teller-poller/src/test/java/com/example/teller/HttpTellerApiTest.java
+++ b/apps/teller-poller/src/test/java/com/example/teller/HttpTellerApiTest.java
@@ -1,0 +1,53 @@
+package com.example.teller;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.net.http.HttpRequest;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class HttpTellerApiTest {
+
+    @Test
+    void listAccountsDelegatesToExecutor() throws Exception {
+        RequestExecutor executor = mock(RequestExecutor.class);
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode sample = mapper.createObjectNode();
+        when(executor.execute(any())).thenReturn(sample);
+
+        HttpTellerApi api = new HttpTellerApi(executor);
+        JsonNode result = api.listAccounts("token123");
+
+        ArgumentCaptor<HttpRequest> captor = ArgumentCaptor.forClass(HttpRequest.class);
+        verify(executor).execute(captor.capture());
+        HttpRequest request = captor.getValue();
+
+        assertEquals("https://api.teller.io/accounts", request.uri().toString());
+        assertEquals("Bearer token123", request.headers().firstValue("Authorization").orElse(""));
+        assertSame(sample, result);
+    }
+
+    @Test
+    void listTransactionsAddsCursorParameter() throws Exception {
+        RequestExecutor executor = mock(RequestExecutor.class);
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode sample = mapper.createObjectNode();
+        when(executor.execute(any())).thenReturn(sample);
+
+        HttpTellerApi api = new HttpTellerApi(executor);
+        JsonNode result = api.listTransactions("tok", "acc1", "cur#1");
+
+        ArgumentCaptor<HttpRequest> captor = ArgumentCaptor.forClass(HttpRequest.class);
+        verify(executor).execute(captor.capture());
+        HttpRequest request = captor.getValue();
+
+        assertEquals("https://api.teller.io/accounts/acc1/transactions?cursor=cur%231", request.uri().toString());
+        assertEquals("Bearer tok", request.headers().firstValue("Authorization").orElse(""));
+        assertSame(sample, result);
+    }
+}

--- a/apps/teller-poller/src/test/java/com/example/teller/RetryingRequestExecutorTest.java
+++ b/apps/teller-poller/src/test/java/com/example/teller/RetryingRequestExecutorTest.java
@@ -1,0 +1,58 @@
+package com.example.teller;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class RetryingRequestExecutorTest {
+
+    @Test
+    void retriesOnFailureAndSucceeds() throws Exception {
+        HttpClient client = mock(HttpClient.class);
+        ObjectMapper mapper = new ObjectMapper();
+
+        HttpResponse<String> first = mock(HttpResponse.class);
+        when(first.statusCode()).thenReturn(500);
+        when(first.body()).thenReturn("oops");
+        HttpResponse<String> second = mock(HttpResponse.class);
+        when(second.statusCode()).thenReturn(200);
+        when(second.body()).thenReturn("{\"ok\":true}");
+
+        when(client.send(any(), ArgumentMatchers.<HttpResponse.BodyHandler<String>>any()))
+            .thenReturn(first, second);
+
+        RetryingRequestExecutor executor = new RetryingRequestExecutor(client, mapper, 3);
+        HttpRequest request = HttpRequest.newBuilder(URI.create("https://test"))
+            .GET().build();
+        JsonNode result = executor.execute(request);
+
+        verify(client, times(2)).send(any(), ArgumentMatchers.<HttpResponse.BodyHandler<String>>any());
+        assertTrue(result.get("ok").asBoolean());
+    }
+
+    @Test
+    void throwsAfterMaxAttempts() throws Exception {
+        HttpClient client = mock(HttpClient.class);
+        ObjectMapper mapper = new ObjectMapper();
+        when(client.send(any(), ArgumentMatchers.<HttpResponse.BodyHandler<String>>any()))
+            .thenThrow(new IOException("fail"));
+
+        RetryingRequestExecutor executor = new RetryingRequestExecutor(client, mapper, 2);
+        HttpRequest request = HttpRequest.newBuilder(URI.create("https://test"))
+            .GET().build();
+
+        assertThrows(IOException.class, () -> executor.execute(request));
+        verify(client, times(2)).send(any(), ArgumentMatchers.<HttpResponse.BodyHandler<String>>any());
+    }
+}

--- a/apps/teller-poller/src/test/java/com/example/teller/TellerClientTest.java
+++ b/apps/teller-poller/src/test/java/com/example/teller/TellerClientTest.java
@@ -1,0 +1,42 @@
+package com.example.teller;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class TellerClientTest {
+
+    @Test
+    void tokensAreCopiedAndImmutable() {
+        List<String> tokens = new ArrayList<>();
+        tokens.add("t1");
+        TellerApi api = mock(TellerApi.class);
+        TellerClient client = new TellerClient(tokens, api);
+
+        tokens.add("t2");
+        assertEquals(List.of("t1"), client.getTokens());
+        assertThrows(UnsupportedOperationException.class, () -> client.getTokens().add("x"));
+    }
+
+    @Test
+    void delegatesToApi() throws Exception {
+        TellerApi api = mock(TellerApi.class);
+        TellerClient client = new TellerClient(List.of("tok"), api);
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode sample = mapper.createObjectNode();
+
+        when(api.listAccounts("tok")).thenReturn(sample);
+        assertSame(sample, client.listAccounts("tok"));
+        verify(api).listAccounts("tok");
+
+        when(api.listTransactions("tok", "acc", null)).thenReturn(sample);
+        assertSame(sample, client.listTransactions("tok", "acc", null));
+        verify(api).listTransactions("tok", "acc", null);
+    }
+}


### PR DESCRIPTION
## Summary
- refactor Teller client into modular classes with dependency injection
- implement RequestExecutor with retry/backoff and HttpTellerApi for account and transaction listing
- add MtlsHttpClientFactory to build mutual TLS HttpClient
- add unit tests for HttpTellerApi, RetryingRequestExecutor, and TellerClient

## Testing
- `gradle test` in `apps/teller-poller`
- `gradle test` in `apps/ingest-service`
- `make build-app` *(fails: buf: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a776ab59548325a0d650d1617daac4