### PR TITLE
Implement scheduled account polling with backfill cursor state

### DIFF
--- a/apps/teller-poller/src/main/java/com/example/poller/AccountPollingService.java
+++ b/apps/teller-poller/src/main/java/com/example/poller/AccountPollingService.java
@@ -1,0 +1,135 @@
+package com.example.poller;
+
+import com.example.teller.TellerClient;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.jooq.DSLContext;
+import org.jooq.Record;
+import org.jooq.impl.DSL;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import jakarta.annotation.PostConstruct;
+import java.io.IOException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.ZoneOffset;
+
+/**
+ * Polls Teller accounts for transactions and maintains cursors.
+ */
+@Service
+public class AccountPollingService {
+    private final DSLContext dsl;
+    private final TellerClient client;
+    private final TimeProvider clock;
+
+    public AccountPollingService(DSLContext dsl, TellerClient client, TimeProvider clock) {
+        this.dsl = dsl;
+        this.client = client;
+        this.clock = clock;
+    }
+
+    @PostConstruct
+    public void backfill() throws IOException, InterruptedException {
+        var accounts = dsl.select(DSL.field("id", Long.class), DSL.field("external_id", String.class))
+                .from("accounts")
+                .where(DSL.field("backfilled_at").isNull())
+                .fetch();
+        for (Record acc : accounts) {
+            long accountId = acc.get(0, Long.class);
+            String externalId = acc.get(1, String.class);
+            String cursor = null;
+            do {
+                JsonNode txs = client.listTransactions(client.getTokens().get(0), externalId, cursor);
+                cursor = persistTransactions(accountId, externalId, txs);
+            } while (cursor != null && !cursor.isBlank());
+            dsl.update(DSL.table("accounts"))
+                .set(DSL.field("backfilled_at"), clock.now())
+                .where(DSL.field("id").eq(accountId))
+                .execute();
+            upsertCursor(accountId, cursor);
+        }
+    }
+
+    @Scheduled(cron = "0 0 * * * *")
+    public void poll() throws IOException, InterruptedException {
+        var states = dsl.select(DSL.field("account_id", Long.class), DSL.field("cursor", String.class))
+                .from("account_poll_state")
+                .fetch();
+        for (Record st : states) {
+            long accountId = st.get(0, Long.class);
+            String cursor = st.get(1, String.class);
+            Record acc = dsl.select(DSL.field("external_id", String.class))
+                    .from("accounts")
+                    .where(DSL.field("id").eq(accountId))
+                    .fetchOne();
+            if (acc == null) continue;
+            String externalId = acc.get(0, String.class);
+            JsonNode txs = client.listTransactions(client.getTokens().get(0), externalId, cursor);
+            String next = persistTransactions(accountId, externalId, txs);
+            upsertCursor(accountId, next);
+        }
+    }
+
+    void upsertCursor(long accountId, String cursor) {
+        dsl.insertInto(DSL.table("account_poll_state"))
+                .set(DSL.field("account_id"), accountId)
+                .set(DSL.field("cursor"), cursor)
+                .set(DSL.field("updated_at"), clock.now())
+                .onConflict(DSL.field("account_id"))
+                .doUpdate()
+                .set(DSL.field("cursor"), cursor)
+                .set(DSL.field("updated_at"), clock.now())
+                .execute();
+    }
+
+    String persistTransactions(long accountId, String externalId, JsonNode txs) {
+        String cursor = null;
+        if (txs == null || !txs.isArray()) return cursor;
+        for (JsonNode node : txs) {
+            Transaction t = new Transaction();
+            t.accountPk = accountId;
+            t.accountId = externalId;
+            t.source = "teller";
+            t.hash = node.path("id").asText();
+            t.amountCents = node.path("amount").path("value").asLong();
+            t.currency = node.path("amount").path("currency").asText("USD");
+            String date = node.path("date").asText(null);
+            if (date != null) {
+                Instant inst = Instant.from(java.time.LocalDate.parse(date).atStartOfDay().atZone(ZoneOffset.UTC));
+                t.occurredAt = inst;
+                t.postedAt = inst;
+            }
+            t.merchant = node.path("description").asText(null);
+            t.type = node.path("type").asText(null);
+            t.memo = node.path("details").path("class").asText(null);
+            t.rawJson = node.toString();
+            upsert(t);
+            cursor = node.path("cursor").asText(null);
+        }
+        return cursor;
+    }
+
+    void upsert(Transaction t) {
+        dsl.insertInto(DSL.table("transactions"))
+                .set(DSL.field("account_id"), t.accountPk)
+                .set(DSL.field("occurred_at"), toTs(t.occurredAt))
+                .set(DSL.field("posted_at"), toTs(t.postedAt))
+                .set(DSL.field("amount_cents"), t.amountCents)
+                .set(DSL.field("currency"), t.currency)
+                .set(DSL.field("merchant"), t.merchant)
+                .set(DSL.field("category"), t.category)
+                .set(DSL.field("txn_type"), t.type)
+                .set(DSL.field("memo"), t.memo)
+                .set(DSL.field("source"), t.source)
+                .set(DSL.field("hash"), t.hash)
+                .set(DSL.field("raw_json"), DSL.field("?::jsonb", String.class, t.rawJson))
+                .onConflict(DSL.field("account_id", Long.class), DSL.field("hash"))
+                .doNothing()
+                .execute();
+    }
+
+    Timestamp toTs(Instant i) {
+        return i == null ? null : Timestamp.from(i);
+    }
+}

--- a/apps/teller-poller/src/main/java/com/example/poller/SystemTimeProvider.java
+++ b/apps/teller-poller/src/main/java/com/example/poller/SystemTimeProvider.java
@@ -1,0 +1,13 @@
+package com.example.poller;
+
+import org.springframework.stereotype.Component;
+
+import java.time.OffsetDateTime;
+
+@Component
+public class SystemTimeProvider implements TimeProvider {
+    @Override
+    public OffsetDateTime now() {
+        return OffsetDateTime.now();
+    }
+}

--- a/apps/teller-poller/src/main/java/com/example/poller/TellerPollerApplication.java
+++ b/apps/teller-poller/src/main/java/com/example/poller/TellerPollerApplication.java
@@ -5,10 +5,12 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.context.annotation.Bean;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 import java.nio.file.Paths;
 
 @SpringBootApplication
+@EnableScheduling
 public class TellerPollerApplication {
     public static void main(String[] args) {
         SpringApplication.run(TellerPollerApplication.class, args);

--- a/apps/teller-poller/src/main/java/com/example/poller/TimeProvider.java
+++ b/apps/teller-poller/src/main/java/com/example/poller/TimeProvider.java
@@ -1,0 +1,7 @@
+package com.example.poller;
+
+import java.time.OffsetDateTime;
+
+public interface TimeProvider {
+    OffsetDateTime now();
+}

--- a/apps/teller-poller/src/test/java/com/example/poller/AccountPollingServiceTest.java
+++ b/apps/teller-poller/src/test/java/com/example/poller/AccountPollingServiceTest.java
@@ -1,0 +1,120 @@
+package com.example.poller;
+
+import com.example.teller.TellerApi;
+import com.example.teller.TellerClient;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.jooq.DSLContext;
+import org.jooq.Field;
+import org.jooq.Record2;
+import org.jooq.Result;
+import org.jooq.exception.DataAccessException;
+import org.jooq.impl.DSL;
+import org.jooq.impl.SQLDataType;
+import org.jooq.tools.jdbc.MockConnection;
+import org.jooq.tools.jdbc.MockDataProvider;
+import org.jooq.tools.jdbc.MockResult;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AccountPollingServiceTest {
+
+    private DSLContext dsl(MockDataProvider provider) {
+        return DSL.using(new MockConnection(provider), org.jooq.SQLDialect.POSTGRES);
+    }
+
+    static class FixedTimeProvider implements TimeProvider {
+        private final OffsetDateTime fixed;
+        FixedTimeProvider(OffsetDateTime fixed) { this.fixed = fixed; }
+        @Override public OffsetDateTime now() { return fixed; }
+    }
+
+    static TellerClient dummyClient() {
+        TellerApi api = new TellerApi() {
+            @Override public JsonNode listAccounts(String token) { return null; }
+            @Override public JsonNode listTransactions(String token, String accountId, String cursor) { return null; }
+        };
+        return new TellerClient(List.of("tok"), api);
+    }
+
+    @Test
+    void backfillDbFailure() {
+        MockDataProvider provider = ctx -> { throw new DataAccessException("fail") {}; };
+        AccountPollingService svc = new AccountPollingService(dsl(provider), dummyClient(), new FixedTimeProvider(OffsetDateTime.parse("2024-01-01T00:00:00Z")));
+        assertThrows(DataAccessException.class, svc::backfill);
+    }
+    @Test
+    void pollDbFailure() {
+        MockDataProvider provider = ctx -> { throw new DataAccessException("fail") {}; };
+        AccountPollingService svc = new AccountPollingService(dsl(provider), dummyClient(), new FixedTimeProvider(OffsetDateTime.parse("2024-01-01T00:00:00Z")));
+        assertThrows(DataAccessException.class, svc::poll);
+    }
+
+    @Test
+    void persistTransactionsReturnsCursor() throws Exception {
+        MockDataProvider provider = ctx -> new MockResult[]{ new MockResult(1, null) };
+        AccountPollingService svc = new AccountPollingService(dsl(provider), dummyClient(), new FixedTimeProvider(OffsetDateTime.parse("2024-01-01T00:00:00Z")));
+        JsonNode txs = new ObjectMapper().readTree("[{\"id\":\"t1\",\"amount\":{\"value\":1},\"cursor\":\"next\"}]");
+        String cursor = svc.persistTransactions(1L, "ext", txs);
+        assertEquals("next", cursor);
+    }
+
+    @Test
+    void persistTransactionsWithNullReturnsNull() {
+        MockDataProvider provider = ctx -> new MockResult[]{ new MockResult(1, null) };
+        AccountPollingService svc = new AccountPollingService(dsl(provider), dummyClient(), new FixedTimeProvider(OffsetDateTime.parse("2024-01-01T00:00:00Z")));
+        assertNull(svc.persistTransactions(1L, "ext", null));
+    }
+
+    @Test
+    void upsertCursorSuccess() {
+        List<String> sqls = new ArrayList<>();
+        MockDataProvider provider = ctx -> { sqls.add(ctx.sql()); return new MockResult[]{ new MockResult(1, null) }; };
+        AccountPollingService svc = new AccountPollingService(dsl(provider), dummyClient(), new FixedTimeProvider(OffsetDateTime.parse("2024-01-01T00:00:00Z")));
+        assertDoesNotThrow(() -> svc.upsertCursor(1L, "c"));
+        assertFalse(sqls.isEmpty());
+    }
+
+    @Test
+    void upsertCursorFailure() {
+        MockDataProvider provider = ctx -> { throw new DataAccessException("fail") {}; };
+        AccountPollingService svc = new AccountPollingService(dsl(provider), dummyClient(), new FixedTimeProvider(OffsetDateTime.parse("2024-01-01T00:00:00Z")));
+        assertThrows(DataAccessException.class, () -> svc.upsertCursor(1L, "c"));
+    }
+
+    @Test
+    void upsertSuccess() {
+        MockDataProvider provider = ctx -> new MockResult[]{ new MockResult(1, null) };
+        AccountPollingService svc = new AccountPollingService(dsl(provider), dummyClient(), new FixedTimeProvider(OffsetDateTime.parse("2024-01-01T00:00:00Z")));
+        Transaction t = new Transaction();
+        t.accountPk = 1L;
+        t.hash = "h";
+        assertDoesNotThrow(() -> svc.upsert(t));
+    }
+
+    @Test
+    void upsertFailure() {
+        MockDataProvider provider = ctx -> { throw new DataAccessException("fail") {}; };
+        AccountPollingService svc = new AccountPollingService(dsl(provider), dummyClient(), new FixedTimeProvider(OffsetDateTime.parse("2024-01-01T00:00:00Z")));
+        Transaction t = new Transaction();
+        t.accountPk = 1L;
+        t.hash = "h";
+        assertThrows(DataAccessException.class, () -> svc.upsert(t));
+    }
+
+    @Test
+    void toTsWorks() {
+        MockDataProvider provider = ctx -> new MockResult[]{ new MockResult(1, null) };
+        AccountPollingService svc = new AccountPollingService(dsl(provider), dummyClient(), new FixedTimeProvider(OffsetDateTime.parse("2024-01-01T00:00:00Z")));
+        Instant now = Instant.now();
+        assertNotNull(svc.toTs(now));
+        assertNull(svc.toTs(null));
+    }
+}

--- a/ops/sql/V5__account_poll_state.sql
+++ b/ops/sql/V5__account_poll_state.sql
@@ -1,0 +1,7 @@
+ALTER TABLE accounts ADD COLUMN backfilled_at TIMESTAMPTZ;
+
+CREATE TABLE IF NOT EXISTS account_poll_state (
+    account_id BIGINT PRIMARY KEY REFERENCES accounts(id) ON DELETE CASCADE,
+    cursor TEXT,
+    updated_at TIMESTAMPTZ DEFAULT now()
+);


### PR DESCRIPTION
## Summary
- backfill accounts lacking marker and track polling cursor
- add hourly scheduled polling service
- record polling metadata via new account_poll_state table
- inject clock abstraction and add unit tests for polling service

## Testing
- `cd apps/teller-poller && ./gradlew --console=plain test` *(fails: wrapper jar missing)*
- `cd apps/teller-poller && gradle --console=plain test`
- `cd apps/ingest-service && gradle --console=plain test`
- `make build-app` *(fails: `buf` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a77e196814832591d2bd16a7eb1189