### PR TITLE
Retry and instrument account polling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 apps/ingest-service/build/
 apps/ingest-service/.gradle/
+apps/teller-poller/build/
+apps/teller-poller/.gradle/
 **/gradle-wrapper.jar
 charts/platform/values.local.yaml

--- a/apps/teller-poller/build.gradle
+++ b/apps/teller-poller/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     runtimeOnly 'org.postgresql:postgresql'
     implementation 'commons-codec:commons-codec:1.15'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'com.h2database:h2:2.2.224'


### PR DESCRIPTION
## Summary
- add Micrometer counters and last-success gauge for account polling
- wrap each account poll with retries and backoff plus structured logging
- include actuator dependency for metrics support

## Testing
- `cd apps/ingest-service && ./gradlew test`
- `cd apps/teller-poller && ./gradlew test`
- `make build-app` *(fails: buf command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a79a1212c883259818abbda8a7e580