### PR TITLE
Add teller poller helm templates

### DIFF
--- a/charts/platform/templates/teller-poller-deployment.yaml
+++ b/charts/platform/templates/teller-poller-deployment.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: teller-poller
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: teller-poller
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: teller-poller
+  template:
+    metadata:
+      labels:
+        app: teller-poller
+    spec:
+      containers:
+        - name: teller-poller
+          image: {{ .Values.tellerPoller.image }}
+          env:
+            - name: DB_URL
+              value: {{ printf "jdbc:postgresql://%s-postgresql.%s.svc.cluster.local:5432/%s" .Release.Name .Values.namespace .Values.postgresql.auth.database | quote }}
+            - name: DB_USER
+              value: {{ .Values.tellerPoller.env.DB_USER | quote }}
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: ingest-db
+                  key: password
+            - name: TELLER_TOKENS
+              valueFrom:
+                secretKeyRef:
+                  name: teller-poller
+                  key: tokens
+            - name: TELLER_CERT
+              valueFrom:
+                secretKeyRef:
+                  name: teller-poller
+                  key: cert
+            - name: TELLER_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: teller-poller
+                  key: key
+            - name: POLL_INTERVAL
+              value: {{ .Values.tellerPoller.pollingInterval | quote }}
+          ports:
+            - containerPort: 8080

--- a/charts/platform/templates/teller-poller-secret.yaml
+++ b/charts/platform/templates/teller-poller-secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: teller-poller
+  namespace: {{ .Values.namespace }}
+stringData:
+  tokens: {{ .Values.secrets.tellerPoller.tokens | quote }}
+  cert: {{ .Values.secrets.tellerPoller.cert | quote }}
+  key: {{ .Values.secrets.tellerPoller.key | quote }}

--- a/charts/platform/templates/teller-poller-service.yaml
+++ b/charts/platform/templates/teller-poller-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: teller-poller
+  namespace: {{ .Values.namespace }}
+spec:
+  selector:
+    app: teller-poller
+  ports:
+    - port: 8080
+      targetPort: 8080

--- a/charts/platform/values.local.sops.yaml
+++ b/charts/platform/values.local.sops.yaml
@@ -3,6 +3,10 @@ secrets:
     db:
         username: ENC[AES256_GCM,data:XJHGJ0p7K4Om,iv:b/R5rGiwrTuJYmmLHgpoMufiiQharf5t8MEbi74wvpc=,tag:rx+K5SbI4Z5LQCJa3m/Vwg==,type:str]
         password: ENC[AES256_GCM,data:vh2yreJRXkTf,iv:grrdxNr+tC7qHqHnaYS6G4iwItVVVfI38Mhd22NMSBw=,tag:mIwZ1p4Gff6SKtbdGKH67g==,type:str]
+    tellerPoller:
+        tokens: ENC[AES256_GCM,data:placeholder,iv:AAAAAAAAAAAAAAAAAAAAAA==,tag:AAAAAAAAAAAAAAAAAAAAAA==,type:str]
+        cert: ENC[AES256_GCM,data:placeholder,iv:AAAAAAAAAAAAAAAAAAAAAA==,tag:AAAAAAAAAAAAAAAAAAAAAA==,type:str]
+        key: ENC[AES256_GCM,data:placeholder,iv:AAAAAAAAAAAAAAAAAAAAAA==,tag:AAAAAAAAAAAAAAAAAAAAAA==,type:str]
 postgresql:
     auth:
         username: ENC[AES256_GCM,data:AQp4nI/n0bu5,iv:9uC50BL59Uob7/CQnk2LfVQhzGQols7RtN5UZBO2xcs=,tag:PifXHDxbMYjG92+tw1rRhA==,type:str]
@@ -10,6 +14,9 @@ postgresql:
 ingestService:
     env:
         DB_USER: ENC[AES256_GCM,data:Nu+jypZsDRuU,iv:Xjaa9J2b1mCDPi0m2Nv85t+TGPg0CyqnYM1AqFHS7kU=,tag:0IhqU6h0gV2uGtCZMVK9gg==,type:str]
+tellerPoller:
+    env:
+        DB_USER: ENC[AES256_GCM,data:placeholder,iv:AAAAAAAAAAAAAAAAAAAAAA==,tag:AAAAAAAAAAAAAAAAAAAAAA==,type:str]
 sops:
     kms: []
     gcp_kms: []

--- a/charts/platform/values.yaml
+++ b/charts/platform/values.yaml
@@ -5,6 +5,10 @@ secrets:
   db:
     username: &db_user ""
     password: &db_password ""
+  tellerPoller:
+    tokens: ""
+    cert: ""
+    key: ""
 
 postgresql:
   primary:
@@ -23,3 +27,9 @@ ingestService:
   hostPaths:
     incoming: /incoming
     processed: /processed
+
+tellerPoller:
+  image: teller-poller:latest
+  env:
+    DB_USER: *db_user
+  pollingInterval: "30s"


### PR DESCRIPTION
## Summary
- add teller-poller deployment, service, and secret templates
- support teller poller config and secrets in Helm values

## Testing
- `cd apps/ingest-service && ./gradlew test` *(fails: Unable to access jarfile gradle/wrapper/gradle-wrapper.jar)*
- `make build-app` *(fails: buf: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a79d25306083259ba0debc9609b2cc