### PR TITLE
docs: add teller-poller runbook

### DIFF
--- a/apps/teller-poller/README.md
+++ b/apps/teller-poller/README.md
@@ -1,0 +1,39 @@
+# Teller Poller
+
+## Configuration
+
+### Tokens and Certificates
+- Set `TELLER_TOKENS` with a comma-separated list of Teller API tokens.
+- Provide `TELLER_CERT` and `TELLER_KEY` containing the PEM-encoded client certificate and private key for mTLS.
+- For local development, edit `charts/platform/values.local.sops.yaml` under `secrets.tellerPoller` using `sops` to supply these values.
+
+## Local Development with Tilt
+1. Populate Teller credentials in `charts/platform/values.local.sops.yaml`.
+2. Build images:
+   ```bash
+   make build-app
+   ```
+3. Launch the stack:
+   ```bash
+   make tilt
+   ```
+4. Access the service at [http://localhost:8080](http://localhost:8080).
+
+## Backfill
+- On startup the poller backfills any account whose `backfilled_at` field is `NULL`.
+- To trigger a fresh backfill for an account, clear its `backfilled_at` in Postgres and restart the teller-poller pod (e.g. `kubectl rollout restart deployment/teller-poller`).
+
+## Operations Runbook
+
+### Health and Metrics
+- Health check: `curl http://teller-poller:8080/actuator/health` should return `{"status":"UP"}`.
+- Metrics are exposed via the Actuator endpoint. Useful metrics:
+  - `account.poll.success`
+  - `account.poll.failure`
+  - `account.poll.last_success.epoch_ms`
+  Fetch using `curl http://teller-poller:8080/actuator/metrics/<metric-name>`.
+
+### Troubleshooting Failed Accounts
+- Inspect logs for `account_poll_failed` or `account_poll_retry` messages which include the account ID and attempt count.
+- Check `account_poll_state` for stuck cursors and ensure the corresponding account has valid tokens.
+- Verify `TELLER_TOKENS`, `TELLER_CERT`, and `TELLER_KEY` are correctly configured and not expired.


### PR DESCRIPTION
## Summary
- document configuring Teller API tokens and mTLS certs
- add local Tilt and backfill instructions
- include operations runbook for health checks and metrics

## Testing
- `gradle test` (apps/ingest-service)
- `gradle test` (apps/teller-poller)
- `make build-app` *(fails: the server hosted at that remote is unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68a7a22de3dc8325b17e4e3ed2b68af9