### PR TITLE
docs: add testing guidance for apps

### DIFF
--- a/apps/AGENTS.md
+++ b/apps/AGENTS.md
@@ -1,0 +1,16 @@
+# Apps Guidelines
+
+## Object-Oriented Design
+
+Prefer dependency injection and object composition as described in
+*Dependency Injection: Principles, Practices, and Patterns* by Mark Seemann and Steven van Deursen.
+Follow the guidelines in Yegor Bugayenko's *Elegant Objects* for small, cohesive classes
+and constructor-based immutability.
+
+## Testing
+
+- Development must be test-driven.
+- Favor integration tests that exercise full API call chains, using a test DB when appropriate.
+- Run `make deps` to install required tooling such as `buf` before building or testing.
+- If `./gradlew` fails due to a missing `gradle-wrapper.jar`, generate it locally with `gradle wrapper` (do not commit the jar).
+


### PR DESCRIPTION
## Summary
- document object-oriented design expectations and testing guidelines in apps/AGENTS.md
- note that `make deps` installs required tools and that `gradle wrapper` can regenerate the wrapper jar

## Testing
- `make deps` (helm: command not found)
- `cd apps/ingest-service && gradle wrapper && ./gradlew test --console=plain` (Could not write XML test results)
- `make build-app` (buf: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68a8d2dc8c948325be2b97f6d31c438d