### PR TITLE
docs: add design guidelines and TDD info

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A minimal personal data platform running on a local k3d Kubernetes cluster. It provisions PostgreSQL and Spring Boot services like ingest-service and teller-poller to normalize CSV bank statements into Postgres.
 
+## Design Guidelines
+
+This project emphasizes object-oriented design with dependency injection and composition to keep classes small, cohesive, and immutable, drawing from Mark Seemann's *Dependency Injection* and Yegor Bugayenko's *Elegant Objects*. Development follows test-driven development with a focus on integration tests and dedicated test databases.
+
 ## Prerequisites
 - Docker (https://docs.docker.com/get-docker/)
 - k3d (e.g., `brew install k3d` or `curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash`)


### PR DESCRIPTION
## Summary
- document OOD and TDD practices in a new "Design Guidelines" section

## Testing
- `gradle test --no-daemon --console=plain`
- `make build-app` *(fails: buf command not found)*
- `make deps` *(fails: helm command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8db90bf1c8325be83c8f44900df4b