### PR TITLE
Refactor install-core and document database Helm values

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,7 @@ deps:
 	buf --version >/dev/null 2>&1 || go install github.com/bufbuild/buf/cmd/buf@latest
 
 install-core:
-	helm dependency update charts/platform
-	helm upgrade --install platform charts/platform -n $(NAMESPACE) -f charts/platform/values.yaml -f charts/platform/values.local.sops.yaml --create-namespace
+	kubectl create namespace $(NAMESPACE) >/dev/null 2>&1 || true
 
 build-app:
 	cd ops/proto && buf generate
@@ -39,7 +38,7 @@ build-app:
 	cd apps/teller-poller && (test -f gradle/wrapper/gradle-wrapper.jar || gradle wrapper --gradle-version 8.4) && ./gradlew bootJar && docker build -t teller-poller:latest .
 
 deploy:
-	helm upgrade --install platform charts/platform -n $(NAMESPACE) -f charts/platform/values.yaml -f charts/platform/values.local.sops.yaml
+	helm upgrade --install platform charts/platform -n $(NAMESPACE) -f charts/platform/values.yaml -f charts/platform/values.local.sops.yaml --create-namespace
 
 tilt:
 	tilt up

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This project emphasizes object-oriented design with dependency injection and com
 ```bash
 make cluster-up        # create k3d cluster
 make deps              # install Helm repo (Bitnami) and buf
-make install-core      # install Postgres
+make install-core      # create namespace
 make build-app         # build ingest-service and teller-poller jars and containers
 make deploy            # deploy ingest-service and CronJob
 make tilt              # start Tilt for live updates
@@ -28,12 +28,22 @@ make tilt              # start Tilt for live updates
 
 `make cluster-up` creates a local registry on port `5001` by default. Override with `REGISTRY_PORT` if needed.
 
+Provide database connection settings via Helm values before deploying:
+
+```yaml
+# charts/platform/values.local.sops.yaml
+db:
+  url: postgresql://<host>:5432/<db>
+  username: <user>
+  password: <pass>
+```
+See `charts/platform/values.sample.yaml` for an unencrypted example.
+
 ### Tilt UI
 
 Run `make tilt` and open [http://localhost:10350](http://localhost:10350). The UI shows:
 - **ingest-service** – Spring Boot app port-forwarded to `localhost:8080`.
 - **ingest-cron** – CronJob that scans `storage/incoming/` for files.
-- **platform-postgresql** – PostgreSQL database from the Bitnami chart.
 
 Tilt rebuilds the ingest-service image and applies Kubernetes updates as source files change.
 

--- a/charts/platform/values.sample.yaml
+++ b/charts/platform/values.sample.yaml
@@ -1,0 +1,7 @@
+# Sample Helm values for database connection
+# Copy to values.local.yaml and adjust for your environment
+
+db:
+  url: postgresql://postgres:postgres@postgresql:5432/postgres
+  username: postgres
+  password: postgres

--- a/charts/platform/values.yaml
+++ b/charts/platform/values.yaml
@@ -2,8 +2,11 @@ namespace: personal
 namespaceCreate: true
 
 db:
+  # JDBC URL for the external Postgres database
   url: ""
+  # Database user
   username: ""
+  # Database password
   password: ""
 
 secrets:


### PR DESCRIPTION
## Summary
- Ensure `install-core` only creates the namespace and drop Helm dependency logic
- Pass `--create-namespace` in `make deploy`
- Document required DB values and add a sample Helm values file

## Testing
- `make deps` *(fails: helm: command not found)*
- `./gradlew test --no-daemon --console=plain`
- `make build-app` *(fails: buf: command not found)*
- `make deploy` *(fails: helm: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8e87c5d2c8325b8591bbb1c64cdc6