### PR TITLE
Add sample environment file and ignore user-specific env

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -1,0 +1,9 @@
+DB_URL=postgresql://postgres:postgres@postgresql:5432/postgres
+DB_USER=postgres
+DB_PASSWORD=postgres
+TELLER_TOKENS=
+TELLER_CERT_FILE=
+TELLER_KEY_FILE=
+CLUSTER_NAME=personal
+NAMESPACE=personal
+REGISTRY_PORT=5001

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ apps/teller-poller/build/
 apps/teller-poller/.gradle/
 **/gradle-wrapper.jar
 charts/platform/values.local.yaml
+.env


### PR DESCRIPTION
## Summary
- add `.env-sample` with common database defaults and teller placeholders
- ignore local `.env` files

## Testing
- `cd apps/ingest-service && ./gradlew test` *(fails: Unable to access jarfile /workspace/local/apps/ingest-service/gradle/wrapper/gradle-wrapper.jar)*
- `make build-app` *(fails: buf: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab5dfe247c8325a1839f02d19986cb