### PR TITLE
Add script to export .env variables

### DIFF
--- a/scripts/export-env.sh
+++ b/scripts/export-env.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENV_FILE="${SCRIPT_DIR}/../.env"
+
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo ".env missing"
+  exit 1
+fi
+
+set -a
+# shellcheck disable=SC1090
+source <(tr -d '\r' < "$ENV_FILE")
+set +a


### PR DESCRIPTION
## Summary
- add `scripts/export-env.sh` to expose `.env` variables in the shell
- improve script for cross-platform use by finding `.env` relative to script and stripping CRLF line endings

## Testing
- `cd apps/ingest-service && ./gradlew test` *(fails: Unable to access jarfile /workspace/local/apps/ingest-service/gradle/wrapper/gradle-wrapper.jar)*
- `make build-app` *(fails: buf: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68ab5ebceb8c8325a793fa8d796cb86a