### PR TITLE
Expand Helm deploy options

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,7 @@ This repo uses a lightweight, role-based workflow to keep changes coherent and s
 
 ## Handoffs
 - **Planner → Infra:** cluster/charts tasks created with acceptance tests.
-- **Infra → App/Data:** DB connection info via `.env` and `values.local.yaml`; service DNS documented.
+- **Infra → App/Data:** DB connection info via `.env` or environment variables; service DNS documented.
 - **Operator feedback → Planner:** Reliability issues become tasks.
 
 ## Guardrails
@@ -72,9 +72,10 @@ and constructor-based immutability.
 
 ## Getting Started (human or agent)
 1. `make cluster-up && make deps && make install-core`
-2. `make build-app && make deploy`
-3. Drop a sample CSV into `storage/incoming/`, or run the app locally pointing at cluster DB.
-4. Iterate with `tilt up` for live dev.
+2. Set `DB_URL`, `DB_USER`, and `DB_PASSWORD` (plus optional `TELLER_TOKENS`, `TELLER_CERT_FILE`, `TELLER_KEY_FILE`).
+3. `make build-app && make deploy`
+4. Drop a sample CSV into `storage/incoming/`, or run the app locally pointing at cluster DB.
+5. Iterate with `tilt up` for live dev.
 
 ## Testing & PRs
 - Run unit tests with `cd apps/ingest-service && ./gradlew test`.

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,14 @@ build-app:
 	cd apps/teller-poller && (test -f gradle/wrapper/gradle-wrapper.jar || gradle wrapper --gradle-version 8.4) && ./gradlew bootJar && docker build -t teller-poller:latest .
 
 deploy:
-	helm upgrade --install platform charts/platform -n $(NAMESPACE) -f charts/platform/values.yaml --create-namespace
+	helm upgrade --install platform charts/platform \
+	-n $(NAMESPACE) -f charts/platform/values.yaml \
+	--set db.url=$(DB_URL) \
+	--set db.username=$(DB_USER) \
+	--set db.password=$(DB_PASSWORD) \
+	--set secrets.tellerPoller.tokens=$(TELLER_TOKENS) \
+	--set-file secrets.tellerPoller.cert=$(TELLER_CERT_FILE) \
+	--set-file secrets.tellerPoller.key=$(TELLER_KEY_FILE)
 
 tilt:
 	tilt up

--- a/README.md
+++ b/README.md
@@ -20,7 +20,13 @@ This project emphasizes object-oriented design with dependency injection and com
 make cluster-up        # create k3d cluster
 make deps              # install Helm repo (Bitnami) and buf
 make install-core      # create namespace
-cp charts/platform/values.sample.yaml charts/platform/values.local.yaml  # set db.url, db.username, db.password
+export DB_URL=postgresql://<host>:5432/<db>
+export DB_USER=<user>
+export DB_PASSWORD=<pass>
+# optional Teller poller credentials
+export TELLER_TOKENS=<token1,token2>
+export TELLER_CERT_FILE=/path/to/cert.pem
+export TELLER_KEY_FILE=/path/to/key.pem
 make build-app         # build ingest-service and teller-poller jars and containers
 make deploy            # deploy ingest-service and CronJob
 make tilt              # start Tilt for live updates
@@ -38,17 +44,15 @@ Tilt rebuilds the ingest-service image and applies Kubernetes updates as source 
 
 ## External Database
 
-The platform expects an existing PostgreSQL instance. Provision a database and user that the cluster can reach and store the connection details in a local values file.
+The platform expects an existing PostgreSQL instance. Provision a database and user that the cluster can reach, then provide the connection details via environment variables when deploying:
 
-```yaml
-# charts/platform/values.local.yaml
-db:
-  url: postgresql://<host>:5432/<db>
-  username: <user>
-  password: <pass>
+```bash
+export DB_URL=postgresql://<host>:5432/<db>
+export DB_USER=<user>
+export DB_PASSWORD=<pass>
 ```
 
-Copy `charts/platform/values.sample.yaml` to `charts/platform/values.local.yaml` and edit as needed.
+You can place these in a local `.env` file so `make deploy` picks them up automatically.
 
 ## Data Ingestion
 
@@ -71,7 +75,7 @@ Copy `charts/platform/values.sample.yaml` to `charts/platform/values.local.yaml`
 - Failed files are moved to `storage/processed/` for inspection.
 
 ## Secrets
-Secrets live in `charts/platform/values.local.yaml`, which is excluded from version control. Copy the sample file and fill in your credentials. Avoid committing plaintext secrets.
+Secrets like database credentials and Teller API tokens are supplied via environment variables or files referenced by them. Store them in a local `.env` file and avoid committing plaintext secrets.
 
 ## Cleanup
 ```bash

--- a/apps/teller-poller/README.md
+++ b/apps/teller-poller/README.md
@@ -4,11 +4,11 @@
 
 ### Tokens and Certificates
 - Set `TELLER_TOKENS` with a comma-separated list of Teller API tokens.
-- Provide `TELLER_CERT` and `TELLER_KEY` containing the PEM-encoded client certificate and private key for mTLS.
-- For local development, edit `charts/platform/values.local.yaml` under `secrets.tellerPoller` to supply these values.
+- Set `TELLER_CERT_FILE` and `TELLER_KEY_FILE` to paths of the PEM-encoded client certificate and private key for mTLS.
+- These environment variables are consumed by `make deploy`.
 
 ## Local Development with Tilt
-1. Populate Teller credentials in `charts/platform/values.local.yaml`.
+1. Export `TELLER_TOKENS`, `TELLER_CERT_FILE`, and `TELLER_KEY_FILE`.
 2. Build images:
    ```bash
    make build-app
@@ -36,4 +36,4 @@
 ### Troubleshooting Failed Accounts
 - Inspect logs for `account_poll_failed` or `account_poll_retry` messages which include the account ID and attempt count.
 - Check `account_poll_state` for stuck cursors and ensure the corresponding account has valid tokens.
-- Verify `TELLER_TOKENS`, `TELLER_CERT`, and `TELLER_KEY` are correctly configured and not expired.
+- Verify `TELLER_TOKENS`, `TELLER_CERT_FILE`, and `TELLER_KEY_FILE` are correctly configured and not expired.

--- a/charts/platform/values.sample.yaml
+++ b/charts/platform/values.sample.yaml
@@ -1,5 +1,5 @@
-# Sample Helm values for database connection
-# Copy to values.local.yaml and adjust for your environment
+# Sample Helm values for database connection.
+# Use as a reference when setting DB_URL/DB_USER/DB_PASSWORD or copy to values.yaml if overriding defaults.
 
 db:
   url: postgresql://postgres:postgres@postgresql:5432/postgres


### PR DESCRIPTION
## Summary
- expose database and teller poller configuration in `make deploy`
- document environment variables in README, AGENTS, and teller-poller docs

## Testing
- `cd apps/ingest-service && ./gradlew test --console=plain` *(terminated early)*
- `make deps` *(fails: helm: command not found)*
- `make build-app` *(fails: buf: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab81bff7a48325abcbb2458190fffd