### PR TITLE
Use env vars for Helm flags in Tiltfile

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -5,19 +5,37 @@ NAMESPACE = os.getenv("NAMESPACE", "personal")
 REGISTRY_PORT = os.getenv("REGISTRY_PORT", "5001")
 default_registry("k3d-%s-registry:%s" % (CLUSTER_NAME, REGISTRY_PORT))
 
-def helm(name, chart, namespace='', values=[]):
+def helm(name, chart, namespace=''):
     cmd = ['helm', 'template', name, chart]
     if namespace:
         cmd += ['--namespace', namespace]
-    for v in values:
-        cmd += ['-f', v]
+    cmd += ['-f', 'charts/platform/values.yaml']
+
+    db_url = os.getenv('DB_URL')
+    if db_url:
+        cmd += ['--set', 'db.url=%s' % db_url]
+    db_user = os.getenv('DB_USER')
+    if db_user:
+        cmd += ['--set', 'db.username=%s' % db_user]
+    db_password = os.getenv('DB_PASSWORD')
+    if db_password:
+        cmd += ['--set', 'db.password=%s' % db_password]
+    teller_tokens = os.getenv('TELLER_TOKENS')
+    if teller_tokens:
+        cmd += ['--set', 'secrets.tellerPoller.tokens=%s' % teller_tokens]
+    teller_cert_file = os.getenv('TELLER_CERT_FILE')
+    if teller_cert_file:
+        cmd += ['--set-file', 'secrets.tellerPoller.cert=%s' % teller_cert_file]
+    teller_key_file = os.getenv('TELLER_KEY_FILE')
+    if teller_key_file:
+        cmd += ['--set-file', 'secrets.tellerPoller.key=%s' % teller_key_file]
+
     return local(cmd, echo_off=False)
 
 helm_release = helm(
     name='platform',
     chart='charts/platform',
     namespace=NAMESPACE,
-    values=['charts/platform/values.yaml'],
 )
 
 docker_build('ingest-service', 'apps/ingest-service')


### PR DESCRIPTION
## Summary
- read DB and Teller env vars in Tiltfile and pass them as `--set`/`--set-file` flags to helm
- drop explicit values list in favor of env-driven flags

## Testing
- `make deps` *(fails: helm: command not found)*
- `cd apps/ingest-service && ./gradlew test --console=plain`
- `make build-app` *(fails: buf: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8667ed4c8325a5dee62530f0ba7d