### PR TITLE
Mount teller poller TLS cert and key

### DIFF
--- a/charts/platform/templates/teller-poller-deployment.yaml
+++ b/charts/platform/templates/teller-poller-deployment.yaml
@@ -33,17 +33,20 @@ spec:
                 secretKeyRef:
                   name: teller-poller
                   key: tokens
-            - name: TELLER_CERT
-              valueFrom:
-                secretKeyRef:
-                  name: teller-poller
-                  key: cert
-            - name: TELLER_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: teller-poller
-                  key: key
+            - name: TELLER_CERT_FILE
+              value: /var/run/secrets/teller/cert.pem
+            - name: TELLER_KEY_FILE
+              value: /var/run/secrets/teller/key.pem
             - name: POLL_INTERVAL
               value: {{ .Values.tellerPoller.pollingInterval | quote }}
           ports:
             - containerPort: 8080
+          volumeMounts:
+            - name: teller-poller-cert
+              mountPath: /var/run/secrets/teller
+              readOnly: true
+
+      volumes:
+        - name: teller-poller-cert
+          secret:
+            secretName: teller-poller

--- a/charts/platform/templates/teller-poller-secret.yaml
+++ b/charts/platform/templates/teller-poller-secret.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: {{ .Values.namespace }}
 stringData:
   tokens: {{ .Values.secrets.tellerPoller.tokens | quote }}
-  cert: {{ .Values.secrets.tellerPoller.cert | quote }}
-  key: {{ .Values.secrets.tellerPoller.key | quote }}
+  cert.pem: {{ .Values.secrets.tellerPoller.cert | quote }}
+  key.pem: {{ .Values.secrets.tellerPoller.key | quote }}


### PR DESCRIPTION
## Summary
- store teller poller cert and key as `cert.pem` and `key.pem` in Secret
- mount secret into deployment and reference cert/key via file paths

## Testing
- `cd apps/ingest-service && gradle test`
- `make build-app` *(fails: Failure: the server hosted at that remote is unavailable.)*

------
https://chatgpt.com/codex/tasks/task_e_68ab885d64f4832580a8ebc500adf820