### PR TITLE
Configure TellerClient from environment

### DIFF
--- a/apps/teller-poller/src/main/java/com/example/teller/TellerClient.java
+++ b/apps/teller-poller/src/main/java/com/example/teller/TellerClient.java
@@ -1,15 +1,12 @@
 package com.example.teller;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import org.springframework.stereotype.Component;
-
 import java.io.IOException;
 import java.util.List;
 
 /**
  * High-level client for interacting with the Teller API.
  */
-@Component
 public final class TellerClient {
 
     private final List<String> tokens;

--- a/apps/teller-poller/src/main/java/com/example/teller/TellerClientConfig.java
+++ b/apps/teller-poller/src/main/java/com/example/teller/TellerClientConfig.java
@@ -1,0 +1,32 @@
+package com.example.teller;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+
+@Configuration
+public final class TellerClientConfig {
+
+    @Bean
+    public TellerClient tellerClient() {
+        String tokensEnv = System.getenv("TELLER_TOKENS");
+        String certFile = System.getenv("TELLER_CERT_FILE");
+        String keyFile = System.getenv("TELLER_KEY_FILE");
+
+        List<String> tokens = (tokensEnv == null || tokensEnv.isBlank()) ? List.of() :
+            Arrays.stream(tokensEnv.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .toList();
+
+        Path certPath = Paths.get(certFile);
+        Path keyPath = Paths.get(keyFile);
+
+        TellerClientFactory factory = new TellerClientFactory(certPath, keyPath);
+        return factory.create(tokens);
+    }
+}


### PR DESCRIPTION
## Summary
- expose TellerClient bean via TellerClientConfig
- remove Spring component annotation from TellerClient

## Testing
- `make deps` *(fails: helm command not found)*
- `cd apps/teller-poller && ./gradlew test`
- `make build-app` *(fails: remote server unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8cd34b188325b983a885637ea952