### PR TITLE
docs: document .env workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,9 @@ This project emphasizes object-oriented design with dependency injection and com
 make cluster-up        # create k3d cluster
 make deps              # install Helm repo (Bitnami) and buf
 make install-core      # create namespace
-export DB_URL=postgresql://<host>:5432/<db>
-export DB_USER=<user>
-export DB_PASSWORD=<pass>
-# optional Teller poller credentials
-export TELLER_TOKENS=<token1,token2>
-export TELLER_CERT_FILE=/path/to/cert.pem
-export TELLER_KEY_FILE=/path/to/key.pem
+cp .env-sample .env    # copy sample env
+# edit .env with DB credentials and optional Teller settings
+source scripts/export-env.sh
 make build-app         # build ingest-service and teller-poller jars and containers
 make deploy            # deploy ingest-service and CronJob
 make tilt              # start Tilt for live updates
@@ -44,15 +40,7 @@ Tilt rebuilds the ingest-service image and applies Kubernetes updates as source 
 
 ## External Database
 
-The platform expects an existing PostgreSQL instance. Provision a database and user that the cluster can reach, then provide the connection details via environment variables when deploying:
-
-```bash
-export DB_URL=postgresql://<host>:5432/<db>
-export DB_USER=<user>
-export DB_PASSWORD=<pass>
-```
-
-You can place these in a local `.env` file so `make deploy` picks them up automatically.
+The platform expects an existing PostgreSQL instance. Provision a database and user that the cluster can reach, then set the connection details in `.env` and run `source scripts/export-env.sh` before deploying so `make deploy` picks them up automatically.
 
 ## Data Ingestion
 
@@ -75,7 +63,7 @@ You can place these in a local `.env` file so `make deploy` picks them up automa
 - Failed files are moved to `storage/processed/` for inspection.
 
 ## Secrets
-Secrets like database credentials and Teller API tokens are supplied via environment variables or files referenced by them. Store them in a local `.env` file and avoid committing plaintext secrets.
+Secrets like database credentials and Teller API tokens live in a local `.env` file. Start from `.env-sample`, populate the values, and run `source scripts/export-env.sh` before building or deploying. The `.env` file is git-ignored—never commit real secrets.
 
 ## Cleanup
 ```bash

--- a/apps/teller-poller/README.md
+++ b/apps/teller-poller/README.md
@@ -2,13 +2,17 @@
 
 ## Configuration
 
-### Tokens and Certificates
-- Set `TELLER_TOKENS` with a comma-separated list of Teller API tokens.
-- Set `TELLER_CERT_FILE` and `TELLER_KEY_FILE` to paths of the PEM-encoded client certificate and private key for mTLS.
-- These environment variables are consumed by `make deploy`.
+1. Copy `.env-sample` from the repository root to `.env` and populate `TELLER_TOKENS`, `TELLER_CERT_FILE`, and `TELLER_KEY_FILE`.
+2. Load the values:
+
+   ```bash
+   source scripts/export-env.sh
+   ```
+
+These environment variables are consumed by `make deploy` and `make tilt`.
 
 ## Local Development with Tilt
-1. Export `TELLER_TOKENS`, `TELLER_CERT_FILE`, and `TELLER_KEY_FILE`.
+1. Ensure the environment variables are loaded (`source scripts/export-env.sh`).
 2. Build images:
    ```bash
    make build-app


### PR DESCRIPTION
## Summary
- document `.env` workflow in root README quickstart, secrets, and external DB sections
- guide teller-poller to use `.env` and export script instead of manual exports

## Testing
- `cd apps/ingest-service && ./gradlew test`
- `make build-app` *(fails: buf: command not found)*
- `make deps` *(fails: helm: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab922d6794832597b40157e91a9912