### PR TITLE
Use local .env for environment variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,12 @@
 SHELL := /bin/bash
 
+# Load environment variables from a local .env file when present so that
+# `make` targets automatically pick up DB credentials and other settings.
+ifneq (,$(wildcard ./.env))
+include .env
+export $(shell sed -n 's/^\([A-Za-z_][A-Za-z0-9_]*\)=.*/\1/p' .env)
+endif
+
 CLUSTER_NAME ?= personal
 NAMESPACE ?= personal
 REGISTRY_NAME ?= $(CLUSTER_NAME)-registry

--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ make deps              # install Helm repo (Bitnami) and buf
 make install-core      # create namespace
 cp .env-sample .env    # copy sample env
 # edit .env with DB credentials and optional Teller settings
-source scripts/export-env.sh
 make build-app         # build ingest-service and teller-poller jars and containers
 make deploy            # deploy ingest-service and CronJob
 make tilt              # start Tilt for live updates
@@ -40,7 +39,7 @@ Tilt rebuilds the ingest-service image and applies Kubernetes updates as source 
 
 ## External Database
 
-The platform expects an existing PostgreSQL instance. Provision a database and user that the cluster can reach, then set the connection details in `.env` and run `source scripts/export-env.sh` before deploying so `make deploy` picks them up automatically.
+The platform expects an existing PostgreSQL instance. Provision a database and user that the cluster can reach, then set the connection details in `.env`. The Makefile and Tiltfile automatically load this file so `make deploy` and `make tilt` pick up the settings.
 
 ## Data Ingestion
 
@@ -63,7 +62,7 @@ The platform expects an existing PostgreSQL instance. Provision a database and u
 - Failed files are moved to `storage/processed/` for inspection.
 
 ## Secrets
-Secrets like database credentials and Teller API tokens live in a local `.env` file. Start from `.env-sample`, populate the values, and run `source scripts/export-env.sh` before building or deploying. The `.env` file is git-ignored—never commit real secrets.
+Secrets like database credentials and Teller API tokens live in a local `.env` file. Start from `.env-sample`, populate the values, and the build/deploy tooling will read them automatically. If you need the variables in your shell for ad-hoc commands, run `source scripts/export-env.sh`. The `.env` file is git-ignored—never commit real secrets.
 
 ## Cleanup
 ```bash

--- a/Tiltfile
+++ b/Tiltfile
@@ -1,3 +1,12 @@
+# Load variables from a local .env file so Tilt picks up settings like DB
+# credentials without requiring a separate `source` step.
+if os.path.exists('.env'):
+    for line in read_file('.env').splitlines():
+        line = line.strip()
+        if line and not line.startswith('#') and '=' in line:
+            key, value = line.split('=', 1)
+            os.putenv(key, value)
+
 # Read environment variables for cluster configuration, falling back to
 # sensible defaults when they are not set.
 CLUSTER_NAME = os.getenv("CLUSTER_NAME", "personal")

--- a/apps/teller-poller/README.md
+++ b/apps/teller-poller/README.md
@@ -3,16 +3,14 @@
 ## Configuration
 
 1. Copy `.env-sample` from the repository root to `.env` and populate `TELLER_TOKENS`, `TELLER_CERT_FILE`, and `TELLER_KEY_FILE`.
-2. Load the values:
+2. These environment variables are consumed automatically by `make deploy` and `make tilt` when `.env` is present. If you need them in your shell for other commands, run:
 
    ```bash
    source scripts/export-env.sh
    ```
 
-These environment variables are consumed by `make deploy` and `make tilt`.
-
 ## Local Development with Tilt
-1. Ensure the environment variables are loaded (`source scripts/export-env.sh`).
+1. Ensure `.env` contains the required variables. The Makefile and Tiltfile will load them automatically (run `source scripts/export-env.sh` only for manual shells).
 2. Build images:
    ```bash
    make build-app


### PR DESCRIPTION
## Summary
- load .env automatically in Makefile and Tiltfile
- document automatic environment variable loading
- clarify teller-poller docs around .env usage

## Testing
- `rg -i "sops" -n`
- `cd apps/ingest-service && gradle wrapper --gradle-version 8.4`
- `cd apps/ingest-service && ./gradlew test`
- `make deps` *(fails: helm: command not found)*
- `apt-get update && apt-get install -y helm` *(installation failed)*
- `curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash` *(installation failed)*
- `make build-app` *(fails: server hosted at that remote is unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68ab9cb619348325a2b253fa8a65cc05