### PR TITLE
Fix Helm namespace ownership error by dropping namespace template

### DIFF
--- a/charts/platform/templates/namespace.yaml
+++ b/charts/platform/templates/namespace.yaml
@@ -1,6 +1,0 @@
-{{- if .Values.namespaceCreate }}
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: {{ .Values.namespace }}
-{{- end }}

--- a/charts/platform/values.yaml
+++ b/charts/platform/values.yaml
@@ -1,5 +1,4 @@
 namespace: personal
-namespaceCreate: true
 
 db:
   # JDBC URL for the external Postgres database


### PR DESCRIPTION
## Summary
- remove namespace Helm template to avoid ownership validation on pre-created namespaces
- stop exposing unused `namespaceCreate` value

## Testing
- `cd apps/ingest-service && ./gradlew test`
- `make deps` *(fails: helm: command not found)*
- `make build-app` *(fails: buf: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aba3de255c8325a9364bcd17f2fc28