### PR TITLE
Fix Tiltfile env parsing

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -1,7 +1,7 @@
 # Load variables from a local .env file so Tilt picks up settings like DB
 # credentials without requiring a separate `source` step.
 if os.path.exists('.env'):
-    for line in read_file('.env').splitlines():
+    for line in read_file('.env').split_lines():
         line = line.strip()
         if line and not line.startswith('#') and '=' in line:
             key, value = line.split('=', 1)


### PR DESCRIPTION
## Summary
- ensure Tilt correctly parses .env file using split_lines

## Testing
- `gradle test --no-daemon`
- `make build-app` (fails: buf: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68abaf10fe3083259eb72a0a220f2269