### PR TITLE
Fix Tiltfile environment parsing

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -1,7 +1,7 @@
 # Load variables from a local .env file so Tilt picks up settings like DB
 # credentials without requiring a separate `source` step.
 if os.path.exists('.env'):
-    for line in read_file('.env').split_lines():
+    for line in read_file('.env').read().splitlines():
         line = line.strip()
         if line and not line.startswith('#') and '=' in line:
             key, value = line.split('=', 1)


### PR DESCRIPTION
## Summary
- ensure `.env` file is parsed as text before splitting into lines

## Testing
- `cd apps/ingest-service && ./gradlew test` *(fails: Unable to access jarfile gradle/wrapper/gradle-wrapper.jar)*
- `make build-app` *(fails: buf: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abbb26f5f48325beece1080b366fc6