### PR TITLE
Derive JDBC datasource URL from DB_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Tilt rebuilds the ingest-service image and applies Kubernetes updates as source 
 
 ## External Database
 
-The platform expects an existing PostgreSQL instance. Provision a database and user that the cluster can reach, then set the connection details in `.env`. The Makefile and Tiltfile automatically load this file so `make deploy` and `make tilt` pick up the settings.
+The platform expects an existing PostgreSQL instance. Provision a database and user that the cluster can reach, then set the connection details in `.env`. The services automatically prefix `DB_URL` with `jdbc:` so other tools can use the same non-JDBC URL. The Makefile and Tiltfile automatically load this file so `make deploy` and `make tilt` pick up the settings.
 
 ## Data Ingestion
 

--- a/apps/ingest-service/src/main/java/com/example/ingest/IngestApplication.java
+++ b/apps/ingest-service/src/main/java/com/example/ingest/IngestApplication.java
@@ -11,6 +11,10 @@ import java.nio.file.Paths;
 @SpringBootApplication
 public class IngestApplication {
     public static void main(String[] args) {
+        String rawUrl = System.getenv("DB_URL");
+        if (rawUrl != null) {
+            System.setProperty("spring.datasource.url", JdbcUrl.from(rawUrl));
+        }
         SpringApplication.run(IngestApplication.class, args);
     }
 

--- a/apps/ingest-service/src/main/java/com/example/ingest/JdbcUrl.java
+++ b/apps/ingest-service/src/main/java/com/example/ingest/JdbcUrl.java
@@ -1,0 +1,16 @@
+package com.example.ingest;
+
+final class JdbcUrl {
+    private JdbcUrl() {}
+
+    static String from(String url) {
+        if (url == null) {
+            return null;
+        }
+        if (url.startsWith("jdbc:")) {
+            return url;
+        }
+        String normalized = url.replaceFirst("^postgres://", "postgresql://");
+        return "jdbc:" + normalized;
+    }
+}

--- a/apps/ingest-service/src/main/resources/application.properties
+++ b/apps/ingest-service/src/main/resources/application.properties
@@ -1,4 +1,3 @@
-spring.datasource.url=${DB_URL}
 spring.datasource.username=${DB_USER}
 spring.datasource.password=${DB_PASSWORD}
 spring.flyway.enabled=true

--- a/apps/ingest-service/src/test/java/com/example/ingest/JdbcUrlTest.java
+++ b/apps/ingest-service/src/test/java/com/example/ingest/JdbcUrlTest.java
@@ -1,0 +1,22 @@
+package com.example.ingest;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class JdbcUrlTest {
+    @Test
+    void prefixesJdbcWhenMissing() {
+        assertEquals("jdbc:postgresql://host/db", JdbcUrl.from("postgresql://host/db"));
+    }
+
+    @Test
+    void leavesJdbcUrlUntouched() {
+        assertEquals("jdbc:postgresql://host/db", JdbcUrl.from("jdbc:postgresql://host/db"));
+    }
+
+    @Test
+    void convertsPostgresAlias() {
+        assertEquals("jdbc:postgresql://host/db", JdbcUrl.from("postgres://host/db"));
+    }
+}

--- a/apps/teller-poller/src/main/java/com/example/poller/JdbcUrl.java
+++ b/apps/teller-poller/src/main/java/com/example/poller/JdbcUrl.java
@@ -1,0 +1,16 @@
+package com.example.poller;
+
+final class JdbcUrl {
+    private JdbcUrl() {}
+
+    static String from(String url) {
+        if (url == null) {
+            return null;
+        }
+        if (url.startsWith("jdbc:")) {
+            return url;
+        }
+        String normalized = url.replaceFirst("^postgres://", "postgresql://");
+        return "jdbc:" + normalized;
+    }
+}

--- a/apps/teller-poller/src/main/java/com/example/poller/TellerPollerApplication.java
+++ b/apps/teller-poller/src/main/java/com/example/poller/TellerPollerApplication.java
@@ -13,6 +13,10 @@ import java.nio.file.Paths;
 @EnableScheduling
 public class TellerPollerApplication {
     public static void main(String[] args) {
+        String rawUrl = System.getenv("DB_URL");
+        if (rawUrl != null) {
+            System.setProperty("spring.datasource.url", JdbcUrl.from(rawUrl));
+        }
         SpringApplication.run(TellerPollerApplication.class, args);
     }
 

--- a/apps/teller-poller/src/main/resources/application.properties
+++ b/apps/teller-poller/src/main/resources/application.properties
@@ -1,4 +1,3 @@
-spring.datasource.url=${DB_URL}
 spring.datasource.username=${DB_USER}
 spring.datasource.password=${DB_PASSWORD}
 spring.flyway.enabled=true

--- a/apps/teller-poller/src/test/java/com/example/poller/JdbcUrlTest.java
+++ b/apps/teller-poller/src/test/java/com/example/poller/JdbcUrlTest.java
@@ -1,0 +1,22 @@
+package com.example.poller;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class JdbcUrlTest {
+    @Test
+    void prefixesJdbcWhenMissing() {
+        assertEquals("jdbc:postgresql://host/db", JdbcUrl.from("postgresql://host/db"));
+    }
+
+    @Test
+    void leavesJdbcUrlUntouched() {
+        assertEquals("jdbc:postgresql://host/db", JdbcUrl.from("jdbc:postgresql://host/db"));
+    }
+
+    @Test
+    void convertsPostgresAlias() {
+        assertEquals("jdbc:postgresql://host/db", JdbcUrl.from("postgres://host/db"));
+    }
+}


### PR DESCRIPTION
## Summary
- let services prefix DB_URL with `jdbc:` at startup so it can stay generic
- restore sample configs and docs to use plain `postgresql://` URLs
- add small helper with tests for converting Postgres URLs to JDBC format

## Testing
- `make deps` *(fails: helm: command not found)*
- `cd apps/ingest-service && ./gradlew test`
- `cd apps/teller-poller && ./gradlew test`
- `make build-app` *(fails: the server hosted at that remote is unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68ac74122b40832584b6d9c9261617ca