### PR TITLE
Log database URL and handle connection failure

### DIFF
--- a/apps/ingest-service/src/main/java/com/example/ingest/DatabaseConfig.java
+++ b/apps/ingest-service/src/main/java/com/example/ingest/DatabaseConfig.java
@@ -1,0 +1,52 @@
+package com.example.ingest;
+
+import javax.sql.DataSource;
+
+import com.zaxxer.hikari.HikariDataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configures the application's {@link DataSource} and logs the connection URL
+ * with sensitive information removed. If the initial connection attempt
+ * fails, the error is logged and the application continues to start so that it
+ * can fail gracefully when the DataSource is first used.
+ */
+@Configuration
+public class DatabaseConfig {
+    private static final Logger log = LoggerFactory.getLogger(DatabaseConfig.class);
+
+    @Bean
+    DataSource dataSource(DataSourceProperties properties) {
+        String url = properties.getUrl();
+        String safeUrl = sanitize(url);
+        if (url != null) {
+            log.info("Attempting database connection to {}", safeUrl);
+        } else {
+            log.warn("No database URL configured");
+        }
+        HikariDataSource ds = properties.initializeDataSourceBuilder()
+                .type(HikariDataSource.class).build();
+        // Try a connection to surface any configuration issues early but don't
+        // prevent the app from starting if it fails.
+        try (var ignored = ds.getConnection()) {
+            log.info("Database connection established");
+        } catch (Exception ex) {
+            log.error("Database connection failed for {}", safeUrl, ex);
+        }
+        return ds;
+    }
+
+    /**
+     * Remove credentials from a JDBC URL so it can be safely logged.
+     */
+    static String sanitize(String url) {
+        if (url == null) {
+            return "";
+        }
+        return url.replaceAll("(?<=//)[^/@]+:[^@]+@", "");
+    }
+}

--- a/apps/ingest-service/src/main/resources/application.properties
+++ b/apps/ingest-service/src/main/resources/application.properties
@@ -1,4 +1,5 @@
 spring.datasource.username=${DB_USER}
 spring.datasource.password=${DB_PASSWORD}
+spring.datasource.url=${DB_URL}
 spring.flyway.enabled=true
 spring.jooq.sql-dialect=POSTGRES

--- a/apps/ingest-service/src/test/java/com/example/ingest/DatabaseConfigTest.java
+++ b/apps/ingest-service/src/test/java/com/example/ingest/DatabaseConfigTest.java
@@ -1,0 +1,13 @@
+package com.example.ingest;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class DatabaseConfigTest {
+    @Test
+    void sanitizeRemovesCredentials() {
+        String url = "jdbc:postgresql://user:secret@host:5432/db";
+        String sanitized = DatabaseConfig.sanitize(url);
+        assertEquals("jdbc:postgresql://host:5432/db", sanitized);
+    }
+}


### PR DESCRIPTION
## Summary
- log database connection URL without credentials
- add DataSource configuration that logs and handles failed connections
- allow DB_URL to populate spring datasource url
- test URL sanitization utility

## Testing
- `./gradlew test`
- `make deps` *(fails: helm: command not found)*
- `make build-app` *(fails: buf: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac7e978fb48325ba22e85681d78e64