### PR TITLE
Support local Helm overrides and document host DB configuration

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -1,4 +1,4 @@
-DB_URL=postgresql://postgresql:5432/postgres
+DB_URL=postgresql://host.docker.internal:5432/postgres
 DB_USER=postgres
 DB_PASSWORD=postgres
 TELLER_TOKENS=

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,11 @@ REGISTRY_PORT ?= 5001
 HOST_REGISTRY ?= localhost:$(REGISTRY_PORT)
 CLUSTER_REGISTRY ?= k3d-$(REGISTRY_NAME):$(REGISTRY_PORT)
 
+VALUES_FILES := -f charts/platform/values.yaml
+ifneq (,$(wildcard charts/platform/values.local.yaml))
+VALUES_FILES += -f charts/platform/values.local.yaml
+endif
+
 cluster-up:
 	@if k3d registry list $(REGISTRY_NAME) >/dev/null 2>&1; then \
 	echo "Using existing registry $(REGISTRY_NAME)"; \
@@ -52,7 +57,7 @@ build-app:
 
 deploy:
 	helm upgrade --install platform charts/platform \
-	-n $(NAMESPACE) -f charts/platform/values.yaml \
+	-n $(NAMESPACE) $(VALUES_FILES) \
 	--set db.url=$(DB_URL) \
 	--set db.username=$(DB_USER) \
 	--set db.password=$(DB_PASSWORD) \

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Tilt rebuilds the ingest-service image and applies Kubernetes updates as source 
 
 The platform expects an existing PostgreSQL instance. Provision a database and user that the cluster can reach, then set the connection details in `.env`. The services automatically prefix `DB_URL` with `jdbc:` so other tools can use the same non-JDBC URL. The Makefile and Tiltfile automatically load this file so `make deploy` and `make tilt` pick up the settings.
 
+Prefer managing overrides in a Helm values file instead? Copy `charts/platform/values.sample.yaml` to `charts/platform/values.local.yaml` and edit the `db` block. Both `make deploy` and `tilt` will include this file when present. When pointing at a database on your host machine, use `host.docker.internal` instead of `localhost` so pods can reach it.
+
 ## Data Ingestion
 
 ### CSV conventions

--- a/Tiltfile
+++ b/Tiltfile
@@ -19,6 +19,9 @@ def helm(name, chart, namespace=''):
     if namespace:
         cmd += ['--namespace', namespace]
     cmd += ['-f', 'charts/platform/values.yaml']
+    local_values = 'charts/platform/values.local.yaml'
+    if os.path.exists(local_values):
+        cmd += ['-f', local_values]
 
     db_url = os.getenv('DB_URL')
     if db_url:

--- a/charts/platform/values.sample.yaml
+++ b/charts/platform/values.sample.yaml
@@ -2,6 +2,6 @@
 # Use as a reference when setting DB_URL/DB_USER/DB_PASSWORD or copy to values.yaml if overriding defaults.
 
 db:
-  url: postgresql://postgresql:5432/postgres
+  url: postgresql://host.docker.internal:5432/postgres
   username: postgres
   password: postgres


### PR DESCRIPTION
## Summary
- load optional `charts/platform/values.local.yaml` so devs can override Helm values without editing tracked files
- point sample env and values files at `host.docker.internal` and document how to supply DB credentials

## Testing
- `cd apps/ingest-service && ./gradlew test`
- `make build-app` *(fails: buf: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac981afe3483258ce51f5fff439a85