### PR TITLE
Fix TellerClient bean configuration

### DIFF
--- a/apps/teller-poller/src/main/java/com/example/poller/TellerPollerApplication.java
+++ b/apps/teller-poller/src/main/java/com/example/poller/TellerPollerApplication.java
@@ -11,7 +11,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 
 import java.nio.file.Paths;
 
-@SpringBootApplication
+@SpringBootApplication(scanBasePackages = "com.example")
 @EnableScheduling
 public class TellerPollerApplication {
     private static final Logger log = LoggerFactory.getLogger(TellerPollerApplication.class);

--- a/apps/teller-poller/src/main/java/com/example/teller/TellerClientConfig.java
+++ b/apps/teller-poller/src/main/java/com/example/teller/TellerClientConfig.java
@@ -4,6 +4,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -11,6 +12,7 @@ import java.util.Arrays;
 import java.util.List;
 
 @Configuration
+@Profile("!test")
 public final class TellerClientConfig {
 
     private static final Logger log = LoggerFactory.getLogger(TellerClientConfig.class);

--- a/apps/teller-poller/src/test/java/com/example/poller/TellerPollerApplicationTest.java
+++ b/apps/teller-poller/src/test/java/com/example/poller/TellerPollerApplicationTest.java
@@ -1,0 +1,29 @@
+package com.example.poller;
+
+import com.example.teller.TellerClient;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(properties = {
+        "DB_USER=sa",
+        "DB_PASSWORD=",
+        "spring.datasource.url=jdbc:h2:mem:testdb;MODE=PostgreSQL;DB_CLOSE_DELAY=-1"
+})
+@ActiveProfiles("test")
+class TellerPollerApplicationTest {
+    @Autowired
+    private TellerClient tellerClient;
+
+    @MockBean
+    private AccountPollingService accountPollingService;
+
+    @Test
+    void contextLoads() {
+        assertThat(tellerClient).isNotNull();
+    }
+}

--- a/apps/teller-poller/src/test/java/com/example/teller/DummyTellerConfig.java
+++ b/apps/teller-poller/src/test/java/com/example/teller/DummyTellerConfig.java
@@ -1,0 +1,30 @@
+package com.example.teller;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+import java.io.IOException;
+import java.util.List;
+
+@Configuration
+@Profile("test")
+class DummyTellerConfig {
+    @Bean
+    public TellerClient tellerClient() {
+        TellerApi api = new TellerApi() {
+            private final ObjectMapper mapper = new ObjectMapper();
+            @Override
+            public JsonNode listAccounts(String token) throws IOException, InterruptedException {
+                return mapper.createArrayNode();
+            }
+            @Override
+            public JsonNode listTransactions(String token, String accountId, String cursor) throws IOException, InterruptedException {
+                return mapper.createArrayNode();
+            }
+        };
+        return new TellerClient(List.of("test"), api);
+    }
+}


### PR DESCRIPTION
## Summary
- ensure TellerClientConfig is picked up by expanding component scan in TellerPollerApplication
- guard TellerClientConfig with a test profile and add integration test verifying context loads

## Testing
- `make deps` *(fails: helm: command not found)*
- `cd apps/teller-poller && ./gradlew test`
- `cd apps/ingest-service && ./gradlew test`
- `make build-app` *(fails: Failure: the server hosted at that remote is unavailable.)*

------
https://chatgpt.com/codex/tasks/task_e_68acb63d61908325a5e8184a68c15392