### PR TITLE
Log transactions and validate teller config

### DIFF
--- a/apps/teller-poller/src/main/java/com/example/poller/AccountPollingService.java
+++ b/apps/teller-poller/src/main/java/com/example/poller/AccountPollingService.java
@@ -4,7 +4,6 @@ import com.example.teller.TellerClient;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
-import org.apache.commons.codec.digest.DigestUtils;
 import org.jooq.DSLContext;
 import org.jooq.Record;
 import org.jooq.impl.DSL;
@@ -15,9 +14,6 @@ import org.springframework.stereotype.Service;
 
 import jakarta.annotation.PostConstruct;
 import java.io.IOException;
-import java.sql.Timestamp;
-import java.time.Instant;
-import java.time.ZoneOffset;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -175,52 +171,9 @@ public class AccountPollingService {
         String cursor = null;
         if (txs == null || !txs.isArray()) return cursor;
         for (JsonNode node : txs) {
-            Transaction t = new Transaction();
-            t.accountPk = accountId;
-            t.accountId = externalId;
-            t.source = "teller";
-            String tellerId = node.path("id").asText();
-            t.hash = DigestUtils.sha256Hex(accountId + ":" + tellerId);
-            t.amountCents = node.path("amount").path("value").asLong();
-            t.currency = node.path("amount").path("currency").asText("USD");
-            String date = node.path("date").asText(null);
-            if (date != null) {
-                Instant inst = Instant.from(java.time.LocalDate.parse(date).atStartOfDay().atZone(ZoneOffset.UTC));
-                t.occurredAt = inst;
-                t.postedAt = inst;
-            }
-            t.merchant = node.path("description").asText(null);
-            t.type = node.path("type").asText(null);
-            t.memo = node.path("details").path("class").asText(null);
-            t.rawJson = node.toString();
-            upsert(t);
+            log.info("transaction accountId={} externalId={} data={}", accountId, externalId, node.toPrettyString());
             cursor = node.path("cursor").asText(null);
         }
         return cursor;
-    }
-
-    void upsert(Transaction t) {
-        try {
-            dsl.insertInto(DSL.table("transactions"))
-                    .set(DSL.field("account_id"), t.accountPk)
-                    .set(DSL.field("occurred_at"), toTs(t.occurredAt))
-                    .set(DSL.field("posted_at"), toTs(t.postedAt))
-                    .set(DSL.field("amount_cents"), t.amountCents)
-                    .set(DSL.field("currency"), t.currency)
-                    .set(DSL.field("merchant", String.class), t.merchant)
-                    .set(DSL.field("category", String.class), t.category)
-                    .set(DSL.field("txn_type", String.class), t.type)
-                    .set(DSL.field("memo", String.class), t.memo)
-                    .set(DSL.field("source"), t.source)
-                    .set(DSL.field("hash"), t.hash)
-                    .set(DSL.field("raw_json", String.class), t.rawJson)
-                    .execute();
-        } catch (org.jooq.exception.DataAccessException ignored) {
-            // likely duplicate
-        }
-    }
-
-    Timestamp toTs(Instant i) {
-        return i == null ? null : Timestamp.from(i);
     }
 }

--- a/apps/teller-poller/src/main/java/com/example/teller/TellerClientConfig.java
+++ b/apps/teller-poller/src/main/java/com/example/teller/TellerClientConfig.java
@@ -14,24 +14,51 @@ import java.util.List;
 @Configuration
 @Profile("!test")
 public final class TellerClientConfig {
-
     private static final Logger log = LoggerFactory.getLogger(TellerClientConfig.class);
+
+    private final String tokensEnv;
+    private final String certFile;
+    private final String keyFile;
+
+    public TellerClientConfig() {
+        this(System.getenv("TELLER_TOKENS"), System.getenv("TELLER_CERT_FILE"), System.getenv("TELLER_KEY_FILE"));
+    }
+
+    // package-private for tests
+    TellerClientConfig(String tokensEnv, String certFile, String keyFile) {
+        this.tokensEnv = tokensEnv;
+        this.certFile = certFile;
+        this.keyFile = keyFile;
+    }
 
     @Bean
     public TellerClient tellerClient() {
-        String tokensEnv = System.getenv("TELLER_TOKENS");
-        String certFile = System.getenv("TELLER_CERT_FILE");
-        String keyFile = System.getenv("TELLER_KEY_FILE");
-        log.info("Starting with TELLER_TOKENS={} TELLER_CERT_FILE={} TELLER_KEY_FILE={}", tokensEnv, certFile, keyFile);
+        if (tokensEnv == null || tokensEnv.isBlank()) {
+            log.error("TELLER_TOKENS is required but was '{}'", tokensEnv);
+            throw new IllegalStateException("TELLER_TOKENS is required");
+        }
+        if (certFile == null || certFile.isBlank()) {
+            log.error("TELLER_CERT_FILE is required but was '{}'", certFile);
+            throw new IllegalStateException("TELLER_CERT_FILE is required");
+        }
+        if (keyFile == null || keyFile.isBlank()) {
+            log.error("TELLER_KEY_FILE is required but was '{}'", keyFile);
+            throw new IllegalStateException("TELLER_KEY_FILE is required");
+        }
 
-        List<String> tokens = (tokensEnv == null || tokensEnv.isBlank()) ? List.of() :
-            Arrays.stream(tokensEnv.split(","))
+        List<String> tokens = Arrays.stream(tokensEnv.split(","))
                 .map(String::trim)
                 .filter(s -> !s.isEmpty())
                 .toList();
+        if (tokens.isEmpty()) {
+            log.error("No valid TELLER_TOKENS provided: {}", tokensEnv);
+            throw new IllegalStateException("TELLER_TOKENS is required");
+        }
 
         Path certPath = Paths.get(certFile);
         Path keyPath = Paths.get(keyFile);
+        log.info("Starting with {} token(s) TELLER_CERT_FILE={} TELLER_KEY_FILE={}",
+                tokens.size(), certPath, keyPath);
 
         try {
             TellerClientFactory factory = new TellerClientFactory(certPath, keyPath);

--- a/apps/teller-poller/src/test/java/com/example/teller/TellerClientConfigTest.java
+++ b/apps/teller-poller/src/test/java/com/example/teller/TellerClientConfigTest.java
@@ -1,0 +1,25 @@
+package com.example.teller;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class TellerClientConfigTest {
+    @Test
+    void missingTokensThrows() {
+        TellerClientConfig cfg = new TellerClientConfig(null, "/tmp/cert.pem", "/tmp/key.pem");
+        assertThrows(IllegalStateException.class, cfg::tellerClient);
+    }
+
+    @Test
+    void missingCertThrows() {
+        TellerClientConfig cfg = new TellerClientConfig("tok", null, "/tmp/key.pem");
+        assertThrows(IllegalStateException.class, cfg::tellerClient);
+    }
+
+    @Test
+    void missingKeyThrows() {
+        TellerClientConfig cfg = new TellerClientConfig("tok", "/tmp/cert.pem", "");
+        assertThrows(IllegalStateException.class, cfg::tellerClient);
+    }
+}


### PR DESCRIPTION
## Summary
- log polled transactions instead of writing to the database
- validate Teller API environment config and fail fast on missing values
- cover new behavior with unit tests

## Testing
- `cd apps/teller-poller && gradle wrapper`
- `cd apps/teller-poller && ./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68acbad3f1c48325ab9c97acc834a8d3