### PR TITLE
Fix Teller Connect enrollment update flow

### DIFF
--- a/apps/teller-connect-update/index.html
+++ b/apps/teller-connect-update/index.html
@@ -36,7 +36,8 @@
 
     document.getElementById("update").addEventListener("click", () => {
       log("Starting update flow...");
-      connect.update({ enrollmentId });
+      // open Teller Connect in update mode for the existing enrollment
+      connect.open({ enrollment: enrollmentId });
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- use `connect.open({ enrollment: ... })` instead of missing `connect.update`

## Testing
- `make deps` *(fails: helm: command not found)*
- `cd apps/ingest-service && ./gradlew test`
- `make build-app` *(fails: buf: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad276eff188325ac1156715529a9cb