### PR TITLE
Add CLI file ingestion option

### DIFF
--- a/apps/ingest-service/src/main/java/com/example/ingest/IngestApplication.java
+++ b/apps/ingest-service/src/main/java/com/example/ingest/IngestApplication.java
@@ -8,6 +8,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.context.annotation.Bean;
 
+import java.nio.file.Path;
 import java.nio.file.Paths;
 
 @SpringBootApplication
@@ -27,11 +28,23 @@ public class IngestApplication {
     @Bean
     CommandLineRunner runner(IngestService service, ApplicationArguments args) {
         return a -> {
-            if (args.containsOption("mode") && args.getOptionValues("mode").contains("scan")) {
-                String input = args.containsOption("input") ? args.getOptionValues("input").get(0) : "/incoming";
-                service.scanAndIngest(Paths.get(input));
+            if (processArgs(service, args)) {
                 System.exit(0);
             }
         };
+    }
+
+    boolean processArgs(IngestService service, ApplicationArguments args) throws Exception {
+        if (args.containsOption("file")) {
+            String file = args.getOptionValues("file").get(0);
+            service.ingestFile(Path.of(file));
+            return true;
+        }
+        if (args.containsOption("mode") && args.getOptionValues("mode").contains("scan")) {
+            String input = args.containsOption("input") ? args.getOptionValues("input").get(0) : "/incoming";
+            service.scanAndIngest(Paths.get(input));
+            return true;
+        }
+        return false;
     }
 }

--- a/apps/ingest-service/src/test/java/com/example/ingest/IngestApplicationTest.java
+++ b/apps/ingest-service/src/test/java/com/example/ingest/IngestApplicationTest.java
@@ -1,0 +1,24 @@
+package com.example.ingest;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.DefaultApplicationArguments;
+
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class IngestApplicationTest {
+    @Test
+    void ingestsFileWhenFileOptionPresent() throws Exception {
+        IngestService service = mock(IngestService.class);
+        DefaultApplicationArguments args = new DefaultApplicationArguments("--file=/tmp/sample.csv");
+        IngestApplication app = new IngestApplication();
+
+        boolean shouldExit = app.processArgs(service, args);
+
+        verify(service).ingestFile(Path.of("/tmp/sample.csv"));
+        assertThat(shouldExit).isTrue();
+    }
+}


### PR DESCRIPTION
## Summary
- allow ingesting a single file via --file argument
- test CLI file ingestion behavior

## Testing
- `make deps` *(fails: helm: command not found)*
- `./gradlew test`
- `make build-app` *(fails: remote server unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68b857bc66848325a740bf94e7583fa7