### PR TITLE
Add directory watch service for CSV ingestion

### DIFF
--- a/apps/ingest-service/src/main/java/com/example/ingest/DirectoryWatchService.java
+++ b/apps/ingest-service/src/main/java/com/example/ingest/DirectoryWatchService.java
@@ -1,0 +1,80 @@
+package com.example.ingest;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.nio.file.*;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+@Service
+public class DirectoryWatchService {
+    private static final Logger log = LoggerFactory.getLogger(DirectoryWatchService.class);
+
+    private final IngestService ingestService;
+    private final Path directory;
+    private final ExecutorService executor;
+    private WatchService watchService;
+
+    public DirectoryWatchService(IngestService ingestService, @Value("${INGEST_DIR:/incoming}") String dir) {
+        this.ingestService = ingestService;
+        this.directory = Paths.get(dir);
+        this.executor = Executors.newSingleThreadExecutor(r -> {
+            Thread t = new Thread(r);
+            t.setDaemon(true);
+            t.setName("directory-watch");
+            return t;
+        });
+    }
+
+    @PostConstruct
+    public void start() throws IOException {
+        Files.createDirectories(directory);
+        watchService = FileSystems.getDefault().newWatchService();
+        directory.register(watchService, StandardWatchEventKinds.ENTRY_CREATE);
+        executor.submit(this::processEvents);
+    }
+
+    @PreDestroy
+    public void stop() throws IOException {
+        executor.shutdownNow();
+        if (watchService != null) {
+            watchService.close();
+        }
+    }
+
+    private void processEvents() {
+        while (!Thread.currentThread().isInterrupted()) {
+            try {
+                WatchKey key = watchService.take();
+                for (WatchEvent<?> event : key.pollEvents()) {
+                    if (event.kind() == StandardWatchEventKinds.ENTRY_CREATE) {
+                        Path filename = (Path) event.context();
+                        if (filename.toString().endsWith(".csv")) {
+                            handleFile(filename);
+                        }
+                    }
+                }
+                key.reset();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } catch (Exception e) {
+                log.error("Watch service error", e);
+            }
+        }
+    }
+
+    private void handleFile(Path filename) throws IOException, com.opencsv.exceptions.CsvException {
+        Path file = directory.resolve(filename);
+        ingestService.ingestFile(file);
+        Path processed = directory.resolve("processed");
+        Files.createDirectories(processed);
+        Files.move(file, processed.resolve(filename), StandardCopyOption.REPLACE_EXISTING);
+    }
+}
+

--- a/apps/ingest-service/src/test/java/com/example/ingest/DirectoryWatchServiceTest.java
+++ b/apps/ingest-service/src/test/java/com/example/ingest/DirectoryWatchServiceTest.java
@@ -1,0 +1,44 @@
+package com.example.ingest;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+
+class DirectoryWatchServiceTest {
+    private DirectoryWatchService watcher;
+
+    @AfterEach
+    void cleanup() throws Exception {
+        if (watcher != null) {
+            watcher.stop();
+        }
+    }
+
+    @Test
+    void ingestsAndMovesNewCsvFiles() throws Exception {
+        Path dir = Files.createTempDirectory("watch");
+        IngestService ingestService = mock(IngestService.class);
+        watcher = new DirectoryWatchService(ingestService, dir.toString());
+        watcher.start();
+
+        Path file = dir.resolve("sample.csv");
+        Files.writeString(file, "id,amount\n1,10");
+
+        Path processed = dir.resolve("processed").resolve("sample.csv");
+        for (int i = 0; i < 50 && !Files.exists(processed); i++) {
+            TimeUnit.MILLISECONDS.sleep(100);
+        }
+
+        verify(ingestService, timeout(5000)).ingestFile(file);
+        assertThat(Files.exists(processed)).isTrue();
+    }
+}
+


### PR DESCRIPTION
## Summary
- watch configurable directory for new CSV files and ingest them
- test CSV file ingestion and processed move on directory watch

## Testing
- `./gradlew test --no-daemon`
- `make deps` *(fails: helm: command not found)*
- `make build-app` *(fails: buf: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8597f9bdc832584b43b970f928cd5