### PR TITLE
Handle CSV errors and continue watch

### DIFF
--- a/apps/ingest-service/src/main/java/com/example/ingest/DirectoryWatchService.java
+++ b/apps/ingest-service/src/main/java/com/example/ingest/DirectoryWatchService.java
@@ -69,12 +69,16 @@ public class DirectoryWatchService {
         }
     }
 
-    private void handleFile(Path filename) throws IOException, com.opencsv.exceptions.CsvException {
+    private void handleFile(Path filename) {
         Path file = directory.resolve(filename);
-        ingestService.ingestFile(file);
-        Path processed = directory.resolve("processed");
-        Files.createDirectories(processed);
-        Files.move(file, processed.resolve(filename), StandardCopyOption.REPLACE_EXISTING);
+        boolean ok = ingestService.ingestFile(file);
+        Path target = directory.resolve(ok ? "processed" : "failed");
+        try {
+            Files.createDirectories(target);
+            Files.move(file, target.resolve(filename), StandardCopyOption.REPLACE_EXISTING);
+        } catch (IOException e) {
+            log.error("Failed to move file {} to {}", file, target, e);
+        }
     }
 }
 

--- a/apps/ingest-service/src/main/java/com/example/ingest/IngestApplication.java
+++ b/apps/ingest-service/src/main/java/com/example/ingest/IngestApplication.java
@@ -37,7 +37,10 @@ public class IngestApplication {
     boolean processArgs(IngestService service, ApplicationArguments args) throws Exception {
         if (args.containsOption("file")) {
             String file = args.getOptionValues("file").get(0);
-            service.ingestFile(Path.of(file));
+            boolean ok = service.ingestFile(Path.of(file));
+            if (!ok) {
+                log.warn("Ingestion failed for {}", file);
+            }
             return true;
         }
         if (args.containsOption("mode") && args.getOptionValues("mode").contains("scan")) {

--- a/apps/ingest-service/src/main/java/com/example/ingest/IngestController.java
+++ b/apps/ingest-service/src/main/java/com/example/ingest/IngestController.java
@@ -16,8 +16,8 @@ public class IngestController {
     }
 
     @PostMapping("/ingest/file")
-    public ResponseEntity<Void> ingest(@RequestParam("path") String path) throws Exception {
-        service.ingestFile(Path.of(path));
-        return ResponseEntity.ok().build();
+    public ResponseEntity<Void> ingest(@RequestParam("path") String path) {
+        boolean ok = service.ingestFile(Path.of(path));
+        return ok ? ResponseEntity.ok().build() : ResponseEntity.internalServerError().build();
     }
 }

--- a/apps/ingest-service/src/test/java/com/example/ingest/DirectoryWatchServiceTest.java
+++ b/apps/ingest-service/src/test/java/com/example/ingest/DirectoryWatchServiceTest.java
@@ -8,9 +8,8 @@ import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.timeout;
-import static org.mockito.Mockito.verify;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 
 class DirectoryWatchServiceTest {
     private DirectoryWatchService watcher;
@@ -26,6 +25,7 @@ class DirectoryWatchServiceTest {
     void ingestsAndMovesNewCsvFiles() throws Exception {
         Path dir = Files.createTempDirectory("watch");
         IngestService ingestService = mock(IngestService.class);
+        when(ingestService.ingestFile(any())).thenReturn(true);
         watcher = new DirectoryWatchService(ingestService, dir.toString());
         watcher.start();
 
@@ -38,6 +38,33 @@ class DirectoryWatchServiceTest {
         }
 
         verify(ingestService, timeout(5000)).ingestFile(file);
+        assertThat(Files.exists(processed)).isTrue();
+    }
+
+    @Test
+    void movesFailedFilesAndContinuesWatching() throws Exception {
+        Path dir = Files.createTempDirectory("watch");
+        IngestService ingestService = mock(IngestService.class);
+        when(ingestService.ingestFile(any())).thenReturn(false, true);
+        watcher = new DirectoryWatchService(ingestService, dir.toString());
+        watcher.start();
+
+        Path bad = dir.resolve("bad.csv");
+        Files.writeString(bad, "id,amount\n1,10");
+        Path failed = dir.resolve("failed").resolve("bad.csv");
+        for (int i = 0; i < 50 && !Files.exists(failed); i++) {
+            TimeUnit.MILLISECONDS.sleep(100);
+        }
+
+        Path good = dir.resolve("good.csv");
+        Files.writeString(good, "id,amount\n1,10");
+        Path processed = dir.resolve("processed").resolve("good.csv");
+        for (int i = 0; i < 50 && !Files.exists(processed); i++) {
+            TimeUnit.MILLISECONDS.sleep(100);
+        }
+
+        verify(ingestService, timeout(5000).times(2)).ingestFile(any());
+        assertThat(Files.exists(failed)).isTrue();
         assertThat(Files.exists(processed)).isTrue();
     }
 }

--- a/apps/ingest-service/src/test/java/com/example/ingest/IngestApplicationTest.java
+++ b/apps/ingest-service/src/test/java/com/example/ingest/IngestApplicationTest.java
@@ -6,13 +6,14 @@ import org.springframework.boot.DefaultApplicationArguments;
 import java.nio.file.Path;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 
 class IngestApplicationTest {
     @Test
     void ingestsFileWhenFileOptionPresent() throws Exception {
         IngestService service = mock(IngestService.class);
+        when(service.ingestFile(any())).thenReturn(true);
         DefaultApplicationArguments args = new DefaultApplicationArguments("--file=/tmp/sample.csv");
         IngestApplication app = new IngestApplication();
 

--- a/apps/ingest-service/src/test/java/com/example/ingest/IngestControllerTest.java
+++ b/apps/ingest-service/src/test/java/com/example/ingest/IngestControllerTest.java
@@ -1,0 +1,33 @@
+package com.example.ingest;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class IngestControllerTest {
+    @Test
+    void returnsServerErrorWhenIngestionFails() {
+        IngestService service = mock(IngestService.class);
+        when(service.ingestFile(any())).thenReturn(false);
+        IngestController controller = new IngestController(service);
+
+        ResponseEntity<Void> resp = controller.ingest("/tmp/sample.csv");
+
+        assertThat(resp.getStatusCode().is5xxServerError()).isTrue();
+    }
+
+    @Test
+    void returnsOkWhenIngestionSucceeds() {
+        IngestService service = mock(IngestService.class);
+        when(service.ingestFile(any())).thenReturn(true);
+        IngestController controller = new IngestController(service);
+
+        ResponseEntity<Void> resp = controller.ingest("/tmp/sample.csv");
+
+        assertThat(resp.getStatusCode().is2xxSuccessful()).isTrue();
+    }
+}

--- a/apps/ingest-service/src/test/java/com/example/ingest/IngestServiceTest.java
+++ b/apps/ingest-service/src/test/java/com/example/ingest/IngestServiceTest.java
@@ -1,0 +1,22 @@
+package com.example.ingest;
+
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class IngestServiceTest {
+    @Test
+    void returnsFalseWhenFileMissing() {
+        DSLContext dsl = mock(DSLContext.class);
+        AccountResolver resolver = mock(AccountResolver.class);
+        IngestService service = new IngestService(dsl, resolver);
+
+        boolean ok = service.ingestFile(Path.of("does-not-exist.csv"));
+
+        assertThat(ok).isFalse();
+    }
+}


### PR DESCRIPTION
## Summary
- Catch CSV parsing and IO errors during ingestion and move failed files aside
- Ensure directory watcher logs and quarantines problematic files instead of stopping
- Return appropriate HTTP status for ingestion requests and cover failure cases in tests

## Testing
- `make deps` *(fails: No rule to make target 'deps')*
- `cd apps/ingest-service && ./gradlew test`
- `make build-app` *(fails: server at remote unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68b85c7d05348325ac146cc8a0e1c558