### PR TITLE
test: cover arg parsing and watch service

### DIFF
--- a/apps/ingest-service/src/test/java/com/example/ingest/DirectoryWatchServiceIntegrationTest.java
+++ b/apps/ingest-service/src/test/java/com/example/ingest/DirectoryWatchServiceIntegrationTest.java
@@ -2,6 +2,7 @@ package com.example.ingest;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -11,7 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
-class DirectoryWatchServiceTest {
+class DirectoryWatchServiceIntegrationTest {
     private DirectoryWatchService watcher;
 
     @AfterEach
@@ -22,8 +23,7 @@ class DirectoryWatchServiceTest {
     }
 
     @Test
-    void ingestsAndMovesNewCsvFiles() throws Exception {
-        Path dir = Files.createTempDirectory("watch");
+    void ingestsAndMovesNewCsvFiles(@TempDir Path dir) throws Exception {
         IngestService ingestService = mock(IngestService.class);
         when(ingestService.ingestFile(any())).thenReturn(true);
         watcher = new DirectoryWatchService(ingestService, dir.toString());
@@ -42,8 +42,7 @@ class DirectoryWatchServiceTest {
     }
 
     @Test
-    void movesFailedFilesAndContinuesWatching() throws Exception {
-        Path dir = Files.createTempDirectory("watch");
+    void movesFailedFilesAndContinuesWatching(@TempDir Path dir) throws Exception {
         IngestService ingestService = mock(IngestService.class);
         when(ingestService.ingestFile(any())).thenReturn(false, true);
         watcher = new DirectoryWatchService(ingestService, dir.toString());

--- a/apps/ingest-service/src/test/java/com/example/ingest/IngestApplicationTest.java
+++ b/apps/ingest-service/src/test/java/com/example/ingest/IngestApplicationTest.java
@@ -22,4 +22,28 @@ class IngestApplicationTest {
         verify(service).ingestFile(Path.of("/tmp/sample.csv"));
         assertThat(shouldExit).isTrue();
     }
+
+    @Test
+    void scansDirectoryWhenModeScanWithInput() throws Exception {
+        IngestService service = mock(IngestService.class);
+        DefaultApplicationArguments args = new DefaultApplicationArguments("--mode=scan", "--input=/tmp/in");
+        IngestApplication app = new IngestApplication();
+
+        boolean shouldExit = app.processArgs(service, args);
+
+        verify(service).scanAndIngest(Path.of("/tmp/in"));
+        assertThat(shouldExit).isTrue();
+    }
+
+    @Test
+    void scansDefaultDirectoryWhenInputMissing() throws Exception {
+        IngestService service = mock(IngestService.class);
+        DefaultApplicationArguments args = new DefaultApplicationArguments("--mode=scan");
+        IngestApplication app = new IngestApplication();
+
+        boolean shouldExit = app.processArgs(service, args);
+
+        verify(service).scanAndIngest(Path.of("/incoming"));
+        assertThat(shouldExit).isTrue();
+    }
 }


### PR DESCRIPTION
## Summary
- add unit tests for IngestApplication argument parsing
- add integration tests for DirectoryWatchService with TempDir

## Testing
- `cd apps/ingest-service && ./gradlew test`
- `make build-app` *(fails: the server hosted at that remote is unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68b8646287508325b476d9a271b372a1