### PR TITLE
Add DB migration and log management scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,19 @@ docker-build: build-app
 # Run the ingest-service container locally pointing at a Postgres database
 # Example usage: `make docker-run DB_URL=jdbc:postgresql://localhost:5432/ingest DB_USER=user DB_PASSWORD=pass`
 docker-run:
-	docker run --rm -p 8080:8080 \
-		-e DB_URL=$(DB_URL) \
-		-e DB_USER=$(DB_USER) \
-		-e DB_PASSWORD=$(DB_PASSWORD) \
+	-docker rm -f ingest-service >/dev/null 2>&1 || true
+	docker run --rm --name ingest-service -p 8080:8080 \\
+		-e DB_URL=$(DB_URL) \\
+		-e DB_USER=$(DB_USER) \\
+		-e DB_PASSWORD=$(DB_PASSWORD) \\
 		ingest-service:latest
 
-.PHONY: build-app docker-build docker-run
+# Apply database migrations using Flyway
+db-migrate:
+	./scripts/migrate.sh
+
+# Tail logs from the running ingest-service container
+docker-logs:
+	./scripts/app-logs.sh
+
+.PHONY: build-app docker-build docker-run db-migrate docker-logs

--- a/scripts/app-logs.sh
+++ b/scripts/app-logs.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CONTAINER_NAME="${1:-ingest-service}"
+
+docker logs -f "$CONTAINER_NAME"

--- a/scripts/migrate.sh
+++ b/scripts/migrate.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Load environment variables from .env if present
+# shellcheck source=./export-env.sh
+source "$SCRIPT_DIR/export-env.sh"
+
+docker run --rm \
+  -v "$ROOT_DIR/ops/sql":/flyway/sql \
+  flyway/flyway \
+  -url="$DB_URL" \
+  -user="$DB_USER" \
+  -password="$DB_PASSWORD" \
+  migrate


### PR DESCRIPTION
## Summary
- add Flyway-based db-migrate script and make target to apply pending migrations
- add helper script and make target for tailing application logs
- name ingest-service container for easier log access

## Testing
- `cd apps/ingest-service && ./gradlew test`
- `make build-app` *(fails: Failure: the server hosted at that remote is unavailable.)*
- `make db-migrate` *(fails: .env missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b86bacd5a4832595422cb1293b1912