### PR TITLE
Fix docker run target and migration DB URL handling

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -1,4 +1,4 @@
-DB_URL=postgresql://host.docker.internal:5432/postgres
+DB_URL=jdbc:postgresql://host.docker.internal:5432/postgres
 DB_USER=postgres
 DB_PASSWORD=postgres
 CLUSTER_NAME=personal

--- a/Makefile
+++ b/Makefile
@@ -20,11 +20,7 @@ docker-build: build-app
 # Example usage: `make docker-run DB_URL=jdbc:postgresql://localhost:5432/ingest DB_USER=user DB_PASSWORD=pass`
 docker-run:
 	-docker rm -f ingest-service >/dev/null 2>&1 || true
-	docker run --rm --name ingest-service -p 8080:8080 \\
-		-e DB_URL=$(DB_URL) \\
-		-e DB_USER=$(DB_USER) \\
-		-e DB_PASSWORD=$(DB_PASSWORD) \\
-		ingest-service:latest
+	docker run --rm --name ingest-service -p 8080:8080 -e DB_URL=$(DB_URL) -e DB_USER=$(DB_USER) -e DB_PASSWORD=$(DB_PASSWORD) ingest-service:latest
 
 # Apply database migrations using Flyway
 db-migrate:

--- a/scripts/migrate.sh
+++ b/scripts/migrate.sh
@@ -8,6 +8,11 @@ ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 # shellcheck source=./export-env.sh
 source "$SCRIPT_DIR/export-env.sh"
 
+# Ensure DB_URL uses JDBC format for Flyway
+if [[ "$DB_URL" != jdbc:* ]]; then
+  DB_URL="jdbc:$DB_URL"
+fi
+
 docker run --rm \
   -v "$ROOT_DIR/ops/sql":/flyway/sql \
   flyway/flyway \


### PR DESCRIPTION
## Summary
- streamline docker-run recipe to run as a single command
- ensure Flyway migrations use JDBC URLs, updating sample env and migrate script

## Testing
- `cd apps/ingest-service && ./gradlew test`
- `make build-app` *(fails: the server hosted at that remote is unavailable)*
- `make db-migrate` *(fails: docker: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b86e3c7e9c8325bbe95bde0722f8e1