### PR TITLE
feat: drop transaction source column

### DIFF
--- a/apps/ingest-service/src/generated/java/com/example/jooq/tables/Transactions.java
+++ b/apps/ingest-service/src/generated/java/com/example/jooq/tables/Transactions.java
@@ -21,7 +21,6 @@ public class Transactions extends TableImpl<Record> {
     public final TableField<Record, String> CATEGORY = createField(DSL.name("category"), SQLDataType.VARCHAR, this, "");
     public final TableField<Record, String> TXN_TYPE = createField(DSL.name("txn_type"), SQLDataType.VARCHAR, this, "");
     public final TableField<Record, String> MEMO = createField(DSL.name("memo"), SQLDataType.VARCHAR, this, "");
-    public final TableField<Record, String> SOURCE = createField(DSL.name("source"), SQLDataType.VARCHAR.nullable(false), this, "");
     public final TableField<Record, String> HASH = createField(DSL.name("hash"), SQLDataType.VARCHAR.nullable(false), this, "");
     public final TableField<Record, JSONB> RAW_JSON = createField(DSL.name("raw_json"), SQLDataType.JSONB.nullable(false), this, "");
     public final TableField<Record, OffsetDateTime> CREATED_AT = createField(DSL.name("created_at"), SQLDataType.TIMESTAMPWITHTIMEZONE, this, "");

--- a/apps/ingest-service/src/main/java/com/example/ingest/IngestService.java
+++ b/apps/ingest-service/src/main/java/com/example/ingest/IngestService.java
@@ -56,7 +56,7 @@ public class IngestService {
                 List<TransactionRecord> txs = reader.read(file, r, ids.externalId());
                 if (txs.isEmpty()) return false;
                 ResolvedAccount account = accountResolver.resolve(shorthand);
-                txs.forEach(t -> upsert(t, account.id(), account.institution()));
+                txs.forEach(t -> upsert(t, account.id()));
                 return true;
             } catch (RuntimeException e) {
                 log.debug("Reader {} failed for {}", reader.getClass().getSimpleName(), file, e);
@@ -69,7 +69,7 @@ public class IngestService {
         return false;
     }
 
-    private void upsert(TransactionRecord t, long accountPk, String source) {
+    private void upsert(TransactionRecord t, long accountPk) {
         dsl.insertInto(DSL.table("transactions"))
                 .set(DSL.field("account_id"), accountPk)
                 .set(DSL.field("occurred_at"), toTs(t.occurredAt()))
@@ -80,7 +80,6 @@ public class IngestService {
                 .set(DSL.field("category"), t.category())
                 .set(DSL.field("txn_type"), t.type())
                 .set(DSL.field("memo"), t.memo())
-                .set(DSL.field("source"), source)
                 .set(DSL.field("hash"), t.hash())
                 .set(DSL.field("raw_json"), DSL.field("?::jsonb", String.class, t.rawJson()))
                 .onConflict(DSL.field("account_id", Long.class), DSL.field("hash"))

--- a/ops/sql/V6__drop_transactions_source.sql
+++ b/ops/sql/V6__drop_transactions_source.sql
@@ -1,0 +1,1 @@
+ALTER TABLE transactions DROP COLUMN source;


### PR DESCRIPTION
## Summary
- remove deprecated `source` field from `transactions` schema
- update ingest upsert to match canonical `TransactionRecord` fields
- regenerate JOOQ classes after schema change

## Testing
- `./gradlew test`
- `./gradlew bootJar`
- `make build-app` *(fails: the server hosted at that remote is unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68b8800fdf0c8325994a9aebb904a57e