### PR TITLE
Drop source field and refresh CSV examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,8 @@ Stop the database with `docker compose down` when finished.
 
 ### CSV conventions
 
-- Include `account_id` and `card_no` columns when available.
-- When those columns are missing, name files as `<source>-<external_id>-*.csv`.
-- Defaults for `account_id` and `source` may also be provided via CLI flags or API parameters.
+- Name files using the account shorthand `<institution><last4>-*.csv`, e.g. `co1828-2025-04.csv`.
+- The shorthand is used as the internal account identifier; CSVs need not include account or source columns.
 
 1. Copy CSV files into `storage/incoming/`.
 2. Run the CLI or service to ingest them.

--- a/apps/ingest-service/src/main/java/com/example/ingest/CapitalOneVentureXTransaction.java
+++ b/apps/ingest-service/src/main/java/com/example/ingest/CapitalOneVentureXTransaction.java
@@ -2,8 +2,7 @@ package com.example.ingest;
 
 import java.time.Instant;
 
-public final class CapitalOneVentureXTransaction implements TransactionRecord, SourceAware {
-    private static final String SOURCE = "capitalone";
+public final class CapitalOneVentureXTransaction implements TransactionRecord {
 
     private final String accountId;
     private final Instant occurredAt;
@@ -75,6 +74,4 @@ public final class CapitalOneVentureXTransaction implements TransactionRecord, S
     @Override
     public String rawJson() { return rawJson; }
 
-    @Override
-    public String source() { return SOURCE; }
 }

--- a/apps/ingest-service/src/main/java/com/example/ingest/ChaseFreedomCsvReader.java
+++ b/apps/ingest-service/src/main/java/com/example/ingest/ChaseFreedomCsvReader.java
@@ -48,6 +48,6 @@ public class ChaseFreedomCsvReader extends BaseCsvReader implements TransactionC
         String occurred = occurredAt == null ? "" : occurredAt.toString();
         String hash = DigestUtils.sha256Hex(accountId + amountCents + occurred + merchant);
         return new GenericTransaction(accountId, occurredAt, postedAt, amountCents,
-                currency, merchant, category, type, memo, hash, rawJson, "chase");
+                currency, merchant, category, type, memo, hash, rawJson);
     }
 }

--- a/apps/ingest-service/src/main/java/com/example/ingest/GenericTransaction.java
+++ b/apps/ingest-service/src/main/java/com/example/ingest/GenericTransaction.java
@@ -2,7 +2,7 @@ package com.example.ingest;
 
 import java.time.Instant;
 
-public final class GenericTransaction implements TransactionRecord, SourceAware {
+public final class GenericTransaction implements TransactionRecord {
     private final String accountId;
     private final Instant occurredAt;
     private final Instant postedAt;
@@ -14,7 +14,6 @@ public final class GenericTransaction implements TransactionRecord, SourceAware 
     private final String memo;
     private final String hash;
     private final String rawJson;
-    private final String source;
 
     public GenericTransaction(
             String accountId,
@@ -27,8 +26,7 @@ public final class GenericTransaction implements TransactionRecord, SourceAware 
             String type,
             String memo,
             String hash,
-            String rawJson,
-            String source) {
+            String rawJson) {
         this.accountId = accountId;
         this.occurredAt = occurredAt;
         this.postedAt = postedAt;
@@ -40,7 +38,6 @@ public final class GenericTransaction implements TransactionRecord, SourceAware 
         this.memo = memo;
         this.hash = hash;
         this.rawJson = rawJson;
-        this.source = source;
     }
 
     @Override
@@ -76,6 +73,4 @@ public final class GenericTransaction implements TransactionRecord, SourceAware 
     @Override
     public String rawJson() { return rawJson; }
 
-    @Override
-    public String source() { return source; }
 }

--- a/apps/ingest-service/src/main/java/com/example/ingest/SourceAware.java
+++ b/apps/ingest-service/src/main/java/com/example/ingest/SourceAware.java
@@ -1,5 +1,0 @@
-package com.example.ingest;
-
-public interface SourceAware {
-    String source();
-}

--- a/apps/ingest-service/src/test/java/com/example/ingest/IngestServiceTest.java
+++ b/apps/ingest-service/src/test/java/com/example/ingest/IngestServiceTest.java
@@ -26,7 +26,7 @@ class IngestServiceTest {
         TransactionCsvReader coReader = mock(TransactionCsvReader.class);
         when(chReader.institution()).thenReturn("ch");
         when(coReader.institution()).thenReturn("co");
-        TransactionRecord dummy = new GenericTransaction("id", null, null, 1, "USD", "m", "c", null, null, "h", "{}", "s");
+        TransactionRecord dummy = new GenericTransaction("id", null, null, 1, "USD", "m", "c", null, null, "h", "{}");
         when(chReader.read(any(), any(), eq("1234"))).thenReturn(List.of(dummy));
         when(coReader.read(any(), any(), eq("1828"))).thenReturn(List.of(dummy));
         when(resolver.resolve("ch1234")).thenReturn(new ResolvedAccount(1L, "ch", "1234"));

--- a/storage/incoming/co1828-example.csv
+++ b/storage/incoming/co1828-example.csv
@@ -1,0 +1,4 @@
+Transaction Date,Posted Date,Card No.,Description,Category,Debit,Credit
+2025-04-30,2025-04-30,1828,CAPITAL ONE MOBILE PYMT,Payment/Credit,,600.00
+04/29/2025,04/30/2025,1828,Café Técnico,Travel,7.50,
+2025-04-28T00:00:00Z,2025-04-28T00:00:00Z,1828,BOOKS,Dining,14.12,

--- a/storage/incoming/sample.csv
+++ b/storage/incoming/sample.csv
@@ -1,4 +1,0 @@
-# Example filename: capitalone-1-sample.csv
-account_id,card_no,occurred_at,posted_at,amount_cents,currency,merchant,category,memo
-1,1234,2024-01-01T10:00:00Z,2024-01-02T10:00:00Z,1234,USD,Store A,Groceries,Weekly shopping
-1,5678,2024-01-03T10:00:00Z,2024-01-04T10:00:00Z,-5678,USD,Store B,Refund,Returned item


### PR DESCRIPTION
## Summary
- remove obsolete SourceAware interface and source column usage
- document shorthand-based CSV naming and replace sample with co1828 example
- adjust readers and tests for source-less TransactionRecord

## Testing
- `./gradlew test`
- `make build-app` *(fails: Failure: the server hosted at that remote is unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68b876f19ffc8325ac994f57094d3b04