### PR TITLE
Use repo storage path as default ingest directory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ This repo uses a lightweight, role-based workflow to keep changes coherent and s
 - Adds tests and sample data.
 
 **Checklist**
-- [ ] CLI `--mode=scan --input=/incoming` ingests sample CSV → Postgres.
+- [ ] CLI `--mode=scan` ingests sample CSV from `storage/incoming` → Postgres.
 - [ ] Unit test covers mapper edge cases (dates, negative amounts, UTF-8).
 - [ ] Docker image builds for arm64/amd64 (if feasible).
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ make docker-run DB_URL=jdbc:postgresql://localhost:5432/ingest DB_USER=ingest DB
 Alternatively, run the CLI directly:
 
 ```bash
-./apps/ingest-service/gradlew -p apps/ingest-service bootRun --args='--mode=scan --input=storage/incoming'
+./apps/ingest-service/gradlew -p apps/ingest-service bootRun --args='--mode=scan'  # defaults to storage/incoming
 ```
 
 Stop the database with `docker compose down` when finished.
@@ -38,7 +38,7 @@ Stop the database with `docker compose down` when finished.
 - The shorthand is used as the internal account identifier; CSVs need not include account or source columns.
 
 1. Copy CSV files into `storage/incoming/`.
-2. Run the CLI or service to ingest them.
+2. Run the CLI or service to ingest them (it watches `storage/incoming/` by default, configurable via `--input` or `INGEST_DIR`).
 3. Processed files move to `storage/processed/` and records are loaded into Postgres.
 
 ### Sample CSVs

--- a/apps/ingest-service/src/main/java/com/example/ingest/DirectoryWatchService.java
+++ b/apps/ingest-service/src/main/java/com/example/ingest/DirectoryWatchService.java
@@ -24,9 +24,9 @@ public class DirectoryWatchService {
     private WatchService watchService;
     private static final Pattern FILE_PATTERN = Pattern.compile("^([a-zA-Z]+\\d{4}).*\\.csv$");
 
-    public DirectoryWatchService(IngestService ingestService, @Value("${INGEST_DIR:/incoming}") String dir) {
+    public DirectoryWatchService(IngestService ingestService, @Value("${INGEST_DIR:storage/incoming}") String dir) {
         this.ingestService = ingestService;
-        this.directory = Paths.get(dir);
+        this.directory = Paths.get(dir).toAbsolutePath();
         this.executor = Executors.newSingleThreadExecutor(r -> {
             Thread t = new Thread(r);
             t.setDaemon(true);

--- a/apps/ingest-service/src/main/java/com/example/ingest/IngestApplication.java
+++ b/apps/ingest-service/src/main/java/com/example/ingest/IngestApplication.java
@@ -46,8 +46,10 @@ public class IngestApplication {
             return true;
         }
         if (args.containsOption("mode") && args.getOptionValues("mode").contains("scan")) {
-            String input = args.containsOption("input") ? args.getOptionValues("input").get(0) : "/incoming";
-            service.scanAndIngest(Paths.get(input));
+            Path input = args.containsOption("input")
+                    ? Path.of(args.getOptionValues("input").get(0))
+                    : Path.of("storage", "incoming");
+            service.scanAndIngest(input);
             return true;
         }
         return false;

--- a/apps/ingest-service/src/test/java/com/example/ingest/IngestApplicationTest.java
+++ b/apps/ingest-service/src/test/java/com/example/ingest/IngestApplicationTest.java
@@ -43,7 +43,7 @@ class IngestApplicationTest {
 
         boolean shouldExit = app.processArgs(service, args);
 
-        verify(service).scanAndIngest(Path.of("/incoming"));
+        verify(service).scanAndIngest(Path.of("storage/incoming"));
         assertThat(shouldExit).isTrue();
     }
 }


### PR DESCRIPTION
## Summary
- Default ingest path to `storage/incoming` for both scan mode and directory watcher
- Clarify ingestion instructions to note new default storage path
- Update unit test to expect the repo storage path

## Testing
- `./apps/ingest-service/gradlew test`
- `make build-app` *(fails: Failure: the server hosted at that remote is unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68b8961080688325bdd07c25f259e099