### PR TITLE
Mount ingest storage and log directory on startup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,10 @@ docker-build: build-app
 # Example usage: `make docker-run DB_URL=jdbc:postgresql://localhost:5432/ingest DB_USER=user DB_PASSWORD=pass`
 docker-run:
 	-docker rm -f ingest-service >/dev/null 2>&1 || true
-	docker run --rm --name ingest-service -p 8080:8080 -e DB_URL=$(DB_URL) -e DB_USER=$(DB_USER) -e DB_PASSWORD=$(DB_PASSWORD) ingest-service:latest
+	docker run --rm --name ingest-service -p 8080:8080 \
+		-e DB_URL=$(DB_URL) -e DB_USER=$(DB_USER) -e DB_PASSWORD=$(DB_PASSWORD) \
+		-v $(PWD)/storage:/app/storage \
+		ingest-service:latest
 
 # Apply database migrations using Flyway
 db-migrate:

--- a/apps/ingest-service/src/main/java/com/example/ingest/DirectoryWatchService.java
+++ b/apps/ingest-service/src/main/java/com/example/ingest/DirectoryWatchService.java
@@ -38,6 +38,7 @@ public class DirectoryWatchService {
     @PostConstruct
     public void start() throws IOException {
         Files.createDirectories(directory);
+        log.info("Watching directory {} for new files", directory);
         watchService = FileSystems.getDefault().newWatchService();
         directory.register(watchService, StandardWatchEventKinds.ENTRY_CREATE);
         executor.submit(this::processEvents);
@@ -54,6 +55,7 @@ public class DirectoryWatchService {
     private void processEvents() {
         while (!Thread.currentThread().isInterrupted()) {
             try {
+                log.debug("Polling {} for changes", directory);
                 WatchKey key = watchService.take();
                 for (WatchEvent<?> event : key.pollEvents()) {
                     if (event.kind() == StandardWatchEventKinds.ENTRY_CREATE) {

--- a/apps/ingest-service/src/main/java/com/example/ingest/IngestApplication.java
+++ b/apps/ingest-service/src/main/java/com/example/ingest/IngestApplication.java
@@ -2,10 +2,11 @@ package com.example.ingest;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.ApplicationArguments;
 import org.springframework.context.annotation.Bean;
 
 import java.nio.file.Path;
@@ -23,6 +24,11 @@ public class IngestApplication {
             System.setProperty("spring.datasource.url", JdbcUrl.from(rawUrl));
         }
         SpringApplication.run(IngestApplication.class, args);
+    }
+
+    @Bean
+    CommandLineRunner ingestDirLogger(@Value("${INGEST_DIR:storage/incoming}") String dir) {
+        return args -> log.info("Using ingest directory {}", Paths.get(dir).toAbsolutePath());
     }
 
     @Bean


### PR DESCRIPTION
## Summary
- mount host storage directory into docker-run target so CSVs are visible to the service
- log configured ingest directory at startup and while polling for files

## Testing
- `make deps` *(fails: No rule to make target 'deps')*
- `cd apps/ingest-service && ./gradlew test --console=plain`
- `make build-app` *(fails: Failure: the server hosted at that remote is unavailable.)*


------
https://chatgpt.com/codex/tasks/task_e_68b89909202c8325bc4ce0002a8c3686