### PR TITLE
Ensure ingest transactions rollback on failure

### DIFF
--- a/apps/ingest-service/src/main/java/com/example/ingest/AccountResolver.java
+++ b/apps/ingest-service/src/main/java/com/example/ingest/AccountResolver.java
@@ -34,8 +34,12 @@ public class AccountResolver {
     public AccountResolver(DSLContext dsl) { this.dsl = dsl; }
 
     public ResolvedAccount resolve(String shorthand) {
+        return resolve(this.dsl, shorthand);
+    }
+
+    public ResolvedAccount resolve(DSLContext ctx, String shorthand) {
         ParsedShorthand ids = parse(shorthand);
-        Record1<Long> existing = dsl.select(Accounts.ACCOUNTS.ID)
+        Record1<Long> existing = ctx.select(Accounts.ACCOUNTS.ID)
                 .from(Accounts.ACCOUNTS)
                 .where(Accounts.ACCOUNTS.INSTITUTION.eq(ids.institution())
                         .and(Accounts.ACCOUNTS.EXTERNAL_ID.eq(ids.externalId())))
@@ -44,7 +48,7 @@ public class AccountResolver {
             return new ResolvedAccount(existing.value1(), ids.institution(), ids.externalId());
         }
         OffsetDateTime now = OffsetDateTime.now();
-        long id = dsl.insertInto(Accounts.ACCOUNTS)
+        long id = ctx.insertInto(Accounts.ACCOUNTS)
                 .set(Accounts.ACCOUNTS.INSTITUTION, ids.institution())
                 .set(Accounts.ACCOUNTS.EXTERNAL_ID, ids.externalId())
                 .set(Accounts.ACCOUNTS.DISPLAY_NAME, ids.externalId())

--- a/apps/ingest-service/src/main/java/com/example/ingest/DirectoryWatchService.java
+++ b/apps/ingest-service/src/main/java/com/example/ingest/DirectoryWatchService.java
@@ -97,7 +97,7 @@ public class DirectoryWatchService {
     private void handleFile(Path filename, String shorthand) {
         Path file = directory.resolve(filename);
         boolean ok = ingestService.ingestFile(file, shorthand);
-        Path target = directory.resolve(ok ? "processed" : "failed");
+        Path target = directory.resolve(ok ? "processed" : "error");
         try {
             Files.createDirectories(target);
             Files.move(file, target.resolve(filename), StandardCopyOption.REPLACE_EXISTING);

--- a/apps/ingest-service/src/test/java/com/example/ingest/DirectoryWatchServiceIntegrationTest.java
+++ b/apps/ingest-service/src/test/java/com/example/ingest/DirectoryWatchServiceIntegrationTest.java
@@ -50,8 +50,8 @@ class DirectoryWatchServiceIntegrationTest {
 
         Path bad = dir.resolve("ch1234-bad.csv");
         Files.writeString(bad, "id,amount\n1,10");
-        Path failed = dir.resolve("failed").resolve("ch1234-bad.csv");
-        for (int i = 0; i < 50 && !Files.exists(failed); i++) {
+        Path error = dir.resolve("error").resolve("ch1234-bad.csv");
+        for (int i = 0; i < 50 && !Files.exists(error); i++) {
             TimeUnit.MILLISECONDS.sleep(100);
         }
 
@@ -63,7 +63,7 @@ class DirectoryWatchServiceIntegrationTest {
         }
 
         verify(ingestService, timeout(5000).times(2)).ingestFile(any(), any());
-        assertThat(Files.exists(failed)).isTrue();
+        assertThat(Files.exists(error)).isTrue();
         assertThat(Files.exists(processed)).isTrue();
     }
 

--- a/apps/ingest-service/src/test/java/com/example/ingest/IngestServiceTest.java
+++ b/apps/ingest-service/src/test/java/com/example/ingest/IngestServiceTest.java
@@ -29,8 +29,8 @@ class IngestServiceTest {
         TransactionRecord dummy = new GenericTransaction("id", null, null, 1, "USD", "m", "c", null, null, "h", "{}");
         when(chReader.read(any(), any(), eq("1234"))).thenReturn(List.of(dummy));
         when(coReader.read(any(), any(), eq("1828"))).thenReturn(List.of(dummy));
-        when(resolver.resolve("ch1234")).thenReturn(new ResolvedAccount(1L, "ch", "1234"));
-        when(resolver.resolve("co1828")).thenReturn(new ResolvedAccount(2L, "co", "1828"));
+        when(resolver.resolve(any(DSLContext.class), eq("ch1234"))).thenReturn(new ResolvedAccount(1L, "ch", "1234"));
+        when(resolver.resolve(any(DSLContext.class), eq("co1828"))).thenReturn(new ResolvedAccount(2L, "co", "1828"));
 
         Files.writeString(dir.resolve("ch1234-example.csv"), "id,amount\n1,10");
         Files.writeString(dir.resolve("co1828-example.csv"), "id,amount\n1,10");
@@ -40,7 +40,7 @@ class IngestServiceTest {
 
         verify(chReader).read(eq(dir.resolve("ch1234-example.csv")), any(), eq("1234"));
         verify(coReader).read(eq(dir.resolve("co1828-example.csv")), any(), eq("1828"));
-        verify(resolver).resolve("ch1234");
-        verify(resolver).resolve("co1828");
+        verify(resolver).resolve(any(DSLContext.class), eq("ch1234"));
+        verify(resolver).resolve(any(DSLContext.class), eq("co1828"));
     }
 }

--- a/apps/ingest-service/src/test/java/com/example/ingest/IngestServiceTransactionTest.java
+++ b/apps/ingest-service/src/test/java/com/example/ingest/IngestServiceTransactionTest.java
@@ -1,0 +1,41 @@
+package com.example.ingest;
+
+import org.jooq.DSLContext;
+import org.jooq.impl.DSL;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+class IngestServiceTransactionTest {
+    @Test
+    void rollsBackWhenUpsertFails(@TempDir Path dir) throws Exception {
+        DSLContext dsl = DSL.using("jdbc:h2:mem:test;MODE=PostgreSQL;DATABASE_TO_UPPER=false", "sa", "");
+        dsl.execute("drop table if exists accounts");
+        dsl.execute("drop table if exists transactions");
+        dsl.execute("create table accounts (id serial primary key, institution varchar not null, external_id varchar not null, display_name varchar not null, created_at timestamp, updated_at timestamp)");
+        dsl.execute("create unique index on accounts(institution, external_id)");
+        dsl.execute("create table transactions (id serial primary key, account_id bigint not null, occurred_at timestamp, posted_at timestamp, amount_cents bigint not null, currency varchar not null, merchant varchar, category varchar, txn_type varchar, memo varchar, hash varchar not null, raw_json clob)");
+        dsl.execute("create unique index on transactions(account_id, hash)");
+
+        AccountResolver resolver = new AccountResolver(dsl);
+        TransactionCsvReader reader = mock(TransactionCsvReader.class);
+        when(reader.institution()).thenReturn("ch");
+        TransactionRecord t1 = new GenericTransaction("a", null, null, 100, "USD", "m", "c", null, null, "h1", "{}");
+        TransactionRecord t2 = new GenericTransaction("a", null, null, 200, "USD", "m", "c", null, null, "h1", "{}");
+        when(reader.read(any(), any(), eq("1234"))).thenReturn(List.of(t1, t2));
+
+        Files.writeString(dir.resolve("ch1234.csv"), "id,amount\n1,10");
+        IngestService service = new IngestService(dsl, resolver, List.of(reader));
+        boolean ok = service.ingestFile(dir.resolve("ch1234.csv"), "ch1234");
+
+        assertThat(ok).isFalse();
+        assertThat(dsl.fetchCount(DSL.table("transactions"))).isZero();
+    }
+}


### PR DESCRIPTION
## Summary
- Wrap ingest operations in a single jOOQ transaction so partial failures roll back
- Move failed ingests to an `error` directory instead of `failed`
- Add regression test verifying transaction rollback on duplicate hashes

## Testing
- `./gradlew test`
- `make build-app` *(fails: Failure: the server hosted at that remote is unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68b89fe7e7808325b5fc2161a81764e8