### PR TITLE
Handle thousands separators in CSV amounts

### DIFF
--- a/apps/ingest-service/src/main/java/com/example/ingest/BaseCsvReader.java
+++ b/apps/ingest-service/src/main/java/com/example/ingest/BaseCsvReader.java
@@ -26,17 +26,21 @@ abstract class BaseCsvReader {
 
     protected long parseAmount(String amount) {
         if (amount == null || amount.isBlank()) return 0;
-        return toCents(new BigDecimal(amount));
+        return toCents(toBigDecimal(amount));
     }
 
     protected long parseAmount(String credit, String debit) {
         if (credit != null && !credit.isBlank()) {
-            return toCents(new BigDecimal(credit));
+            return toCents(toBigDecimal(credit));
         }
         if (debit != null && !debit.isBlank()) {
-            return -toCents(new BigDecimal(debit));
+            return -toCents(toBigDecimal(debit));
         }
         return 0;
+    }
+
+    private BigDecimal toBigDecimal(String amount) {
+        return new BigDecimal(amount.replace(",", ""));
     }
 
     private long toCents(BigDecimal v) {

--- a/apps/ingest-service/src/test/java/com/example/ingest/BaseCsvReaderTest.java
+++ b/apps/ingest-service/src/test/java/com/example/ingest/BaseCsvReaderTest.java
@@ -1,0 +1,20 @@
+package com.example.ingest;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class BaseCsvReaderTest {
+    static class Stub extends BaseCsvReader {
+        long amt(String amount) { return parseAmount(amount); }
+        long amt(String credit, String debit) { return parseAmount(credit, debit); }
+    }
+
+    @Test
+    void parsesAmountsWithThousandsSeparators() {
+        Stub s = new Stub();
+        assertEquals(123456, s.amt("1,234.56"));
+        assertEquals(123456, s.amt("1,234.56", null));
+        assertEquals(-123456, s.amt(null, "1,234.56"));
+    }
+}


### PR DESCRIPTION
## Summary
- support parsing amounts containing commas in ingest CSV readers
- add unit test for amounts with thousands separators

## Testing
- `make deps` *(fails: No rule to make target 'deps')*
- `cd apps/ingest-service && ./gradlew test`
- `make build-app` *(fails: the server hosted at that remote is unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68b8a8c44dc88325858ce4b0a1b89163