### PR TITLE
Handle unpadded dates in CSV reader

### DIFF
--- a/apps/ingest-service/src/main/java/org/artificers/ingest/BaseCsvReader.java
+++ b/apps/ingest-service/src/main/java/org/artificers/ingest/BaseCsvReader.java
@@ -18,7 +18,7 @@ abstract class BaseCsvReader {
                 LocalDate d = LocalDate.parse(v, DateTimeFormatter.ISO_DATE);
                 return d.atStartOfDay(ZoneOffset.UTC).toInstant();
             } catch (DateTimeParseException e2) {
-                LocalDate d = LocalDate.parse(v, DateTimeFormatter.ofPattern("MM/dd/yyyy"));
+                LocalDate d = LocalDate.parse(v, DateTimeFormatter.ofPattern("M/d/yyyy"));
                 return d.atStartOfDay(ZoneOffset.UTC).toInstant();
             }
         }

--- a/apps/ingest-service/src/test/java/org/artificers/ingest/BaseCsvReaderTest.java
+++ b/apps/ingest-service/src/test/java/org/artificers/ingest/BaseCsvReaderTest.java
@@ -8,6 +8,7 @@ class BaseCsvReaderTest {
     static class Stub extends BaseCsvReader {
         long amt(String amount) { return parseAmount(amount); }
         long amt(String credit, String debit) { return parseAmount(credit, debit); }
+        java.time.Instant date(String v) { return parseDate(v); }
     }
 
     @Test
@@ -16,5 +17,13 @@ class BaseCsvReaderTest {
         assertEquals(123456, s.amt("1,234.56"));
         assertEquals(123456, s.amt("1,234.56", null));
         assertEquals(-123456, s.amt(null, "1,234.56"));
+    }
+
+    @Test
+    void parsesDatesWithoutLeadingZeros() {
+        Stub s = new Stub();
+        java.time.Instant expected = java.time.LocalDate.of(2025, 5, 3)
+                .atStartOfDay(java.time.ZoneOffset.UTC).toInstant();
+        assertEquals(expected, s.date("5/3/2025"));
     }
 }


### PR DESCRIPTION
## Summary
- allow CSV ingestion to parse dates like `5/3/2025` without leading zeros
- test BaseCsvReader against unpadded month/day values

## Testing
- `./gradlew test`
- `make build-app` *(fails: the server hosted at that remote is unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b9ee1f308325888f95ea56c227e9