### PR TITLE
Split transactions into account tables

### DIFF
--- a/apps/ingest-service/src/generated/java/org/artificers/jooq/Tables.java
+++ b/apps/ingest-service/src/generated/java/org/artificers/jooq/Tables.java
@@ -1,9 +1,11 @@
 package org.artificers.jooq;
 
 import org.artificers.jooq.tables.Accounts;
-import org.artificers.jooq.tables.Transactions;
+import org.artificers.jooq.tables.ChaseTransactions;
+import org.artificers.jooq.tables.CapitalOneTransactions;
 
 public class Tables {
     public static final Accounts ACCOUNTS = Accounts.ACCOUNTS;
-    public static final Transactions TRANSACTIONS = Transactions.TRANSACTIONS;
+    public static final ChaseTransactions CHASE_TRANSACTIONS = ChaseTransactions.CHASE_TRANSACTIONS;
+    public static final CapitalOneTransactions CAPITAL_ONE_TRANSACTIONS = CapitalOneTransactions.CAPITAL_ONE_TRANSACTIONS;
 }

--- a/apps/ingest-service/src/generated/java/org/artificers/jooq/tables/CapitalOneTransactions.java
+++ b/apps/ingest-service/src/generated/java/org/artificers/jooq/tables/CapitalOneTransactions.java
@@ -1,0 +1,30 @@
+package org.artificers.jooq.tables;
+
+import java.time.OffsetDateTime;
+import org.jooq.JSONB;
+import org.jooq.Record;
+import org.jooq.TableField;
+import org.jooq.impl.DSL;
+import org.jooq.impl.SQLDataType;
+import org.jooq.impl.TableImpl;
+
+public class CapitalOneTransactions extends TableImpl<Record> {
+    public static final CapitalOneTransactions CAPITAL_ONE_TRANSACTIONS = new CapitalOneTransactions();
+
+    public final TableField<Record, Long> ID = createField(DSL.name("id"), SQLDataType.BIGINT.identity(true), this, "");
+    public final TableField<Record, OffsetDateTime> OCCURRED_AT = createField(DSL.name("occurred_at"), SQLDataType.TIMESTAMPWITHTIMEZONE, this, "");
+    public final TableField<Record, OffsetDateTime> POSTED_AT = createField(DSL.name("posted_at"), SQLDataType.TIMESTAMPWITHTIMEZONE, this, "");
+    public final TableField<Record, Long> AMOUNT_CENTS = createField(DSL.name("amount_cents"), SQLDataType.BIGINT.nullable(false), this, "");
+    public final TableField<Record, String> CURRENCY = createField(DSL.name("currency"), SQLDataType.VARCHAR.nullable(false), this, "");
+    public final TableField<Record, String> MERCHANT = createField(DSL.name("merchant"), SQLDataType.VARCHAR, this, "");
+    public final TableField<Record, String> CATEGORY = createField(DSL.name("category"), SQLDataType.VARCHAR, this, "");
+    public final TableField<Record, String> TXN_TYPE = createField(DSL.name("txn_type"), SQLDataType.VARCHAR, this, "");
+    public final TableField<Record, String> MEMO = createField(DSL.name("memo"), SQLDataType.VARCHAR, this, "");
+    public final TableField<Record, String> HASH = createField(DSL.name("hash"), SQLDataType.VARCHAR.nullable(false), this, "");
+    public final TableField<Record, JSONB> RAW_JSON = createField(DSL.name("raw_json"), SQLDataType.JSONB.nullable(false), this, "");
+    public final TableField<Record, OffsetDateTime> CREATED_AT = createField(DSL.name("created_at"), SQLDataType.TIMESTAMPWITHTIMEZONE, this, "");
+
+    private CapitalOneTransactions() {
+        super(DSL.name("capital_one_transactions"));
+    }
+}

--- a/apps/ingest-service/src/generated/java/org/artificers/jooq/tables/ChaseTransactions.java
+++ b/apps/ingest-service/src/generated/java/org/artificers/jooq/tables/ChaseTransactions.java
@@ -8,11 +8,10 @@ import org.jooq.impl.DSL;
 import org.jooq.impl.SQLDataType;
 import org.jooq.impl.TableImpl;
 
-public class Transactions extends TableImpl<Record> {
-    public static final Transactions TRANSACTIONS = new Transactions();
+public class ChaseTransactions extends TableImpl<Record> {
+    public static final ChaseTransactions CHASE_TRANSACTIONS = new ChaseTransactions();
 
     public final TableField<Record, Long> ID = createField(DSL.name("id"), SQLDataType.BIGINT.identity(true), this, "");
-    public final TableField<Record, Long> ACCOUNT_ID = createField(DSL.name("account_id"), SQLDataType.BIGINT.nullable(false), this, "");
     public final TableField<Record, OffsetDateTime> OCCURRED_AT = createField(DSL.name("occurred_at"), SQLDataType.TIMESTAMPWITHTIMEZONE, this, "");
     public final TableField<Record, OffsetDateTime> POSTED_AT = createField(DSL.name("posted_at"), SQLDataType.TIMESTAMPWITHTIMEZONE, this, "");
     public final TableField<Record, Long> AMOUNT_CENTS = createField(DSL.name("amount_cents"), SQLDataType.BIGINT.nullable(false), this, "");
@@ -25,8 +24,7 @@ public class Transactions extends TableImpl<Record> {
     public final TableField<Record, JSONB> RAW_JSON = createField(DSL.name("raw_json"), SQLDataType.JSONB.nullable(false), this, "");
     public final TableField<Record, OffsetDateTime> CREATED_AT = createField(DSL.name("created_at"), SQLDataType.TIMESTAMPWITHTIMEZONE, this, "");
 
-    private Transactions() {
-        super(DSL.name("transactions"));
+    private ChaseTransactions() {
+        super(DSL.name("chase_transactions"));
     }
 }
-

--- a/apps/ingest-service/src/test/java/org/artificers/ingest/IngestServiceTransactionTest.java
+++ b/apps/ingest-service/src/test/java/org/artificers/ingest/IngestServiceTransactionTest.java
@@ -2,7 +2,8 @@ package org.artificers.ingest;
 
 import org.jooq.DSLContext;
 import org.jooq.impl.DSL;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.nio.file.Files;
@@ -14,28 +15,29 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 class IngestServiceTransactionTest {
-    @Test
-    void ignoresDuplicateTransactions(@TempDir Path dir) throws Exception {
+    @ParameterizedTest
+    @CsvSource({"ch,chase_transactions", "co,capital_one_transactions"})
+    void ignoresDuplicateTransactions(String institution, String table, @TempDir Path dir) throws Exception {
         DSLContext dsl = DSL.using("jdbc:h2:mem:test;MODE=PostgreSQL;DATABASE_TO_UPPER=false", "sa", "");
         dsl.execute("drop table if exists accounts");
-        dsl.execute("drop table if exists transactions");
+        dsl.execute("drop table if exists " + table);
         dsl.execute("create table accounts (id serial primary key, institution varchar not null, external_id varchar not null, display_name varchar not null, created_at timestamp, updated_at timestamp)");
         dsl.execute("create unique index on accounts(institution, external_id)");
-        dsl.execute("create table transactions (id serial primary key, account_id bigint not null, occurred_at timestamp, posted_at timestamp, amount_cents bigint not null, currency varchar not null, merchant varchar, category varchar, txn_type varchar, memo varchar, hash varchar not null, raw_json clob)");
-        dsl.execute("create unique index on transactions(account_id, hash)");
+        dsl.execute("create table " + table + " (id serial primary key, occurred_at timestamp, posted_at timestamp, amount_cents bigint not null, currency varchar not null, merchant varchar, category varchar, txn_type varchar, memo varchar, hash varchar not null, raw_json clob)");
+        dsl.execute("create unique index on " + table + "(hash)");
 
         AccountResolver resolver = new AccountResolver(dsl);
         TransactionCsvReader reader = mock(TransactionCsvReader.class);
-        when(reader.institution()).thenReturn("ch");
+        when(reader.institution()).thenReturn(institution);
         TransactionRecord t1 = new GenericTransaction("a", null, null, 100, "USD", "m", "c", null, null, "h1", "{}");
         TransactionRecord t2 = new GenericTransaction("a", null, null, 200, "USD", "m", "c", null, null, "h1", "{}");
         when(reader.read(any(), any(), eq("1234"))).thenReturn(List.of(t1, t2));
 
-        Files.writeString(dir.resolve("ch1234.csv"), "id,amount\n1,10");
+        Files.writeString(dir.resolve(institution + "1234.csv"), "id,amount\n1,10");
         IngestService service = new IngestService(dsl, resolver, List.of(reader));
-        boolean ok = service.ingestFile(dir.resolve("ch1234.csv"), "ch1234");
+        boolean ok = service.ingestFile(dir.resolve(institution + "1234.csv"), institution + "1234");
 
         assertThat(ok).isTrue();
-        assertThat(dsl.fetchCount(DSL.table("transactions"))).isEqualTo(1);
+        assertThat(dsl.fetchCount(DSL.table(table))).isEqualTo(1);
     }
 }

--- a/apps/ingest-service/src/test/java/org/artificers/ingest/SchemaConsistencyTest.java
+++ b/apps/ingest-service/src/test/java/org/artificers/ingest/SchemaConsistencyTest.java
@@ -1,6 +1,7 @@
 package org.artificers.ingest;
 
-import org.artificers.jooq.tables.Transactions;
+import org.artificers.jooq.tables.ChaseTransactions;
+import org.artificers.jooq.tables.CapitalOneTransactions;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -17,9 +18,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class SchemaConsistencyTest {
     @Test
     void databaseColumnTypesMatchExpectations() {
-        assertThat(Transactions.TRANSACTIONS.AMOUNT_CENTS.getDataType().getType())
+        assertThat(ChaseTransactions.CHASE_TRANSACTIONS.AMOUNT_CENTS.getDataType().getType())
                 .isEqualTo(Long.class);
-        assertThat(Transactions.TRANSACTIONS.CURRENCY.getDataType().getType())
+        assertThat(CapitalOneTransactions.CAPITAL_ONE_TRANSACTIONS.AMOUNT_CENTS.getDataType().getType())
+                .isEqualTo(Long.class);
+        assertThat(ChaseTransactions.CHASE_TRANSACTIONS.CURRENCY.getDataType().getType())
+                .isEqualTo(String.class);
+        assertThat(CapitalOneTransactions.CAPITAL_ONE_TRANSACTIONS.CURRENCY.getDataType().getType())
                 .isEqualTo(String.class);
     }
 

--- a/ops/sql/V7__split_transactions_by_account.sql
+++ b/ops/sql/V7__split_transactions_by_account.sql
@@ -1,0 +1,37 @@
+DROP TABLE IF EXISTS transactions;
+
+CREATE TABLE IF NOT EXISTS chase_transactions (
+    id BIGSERIAL PRIMARY KEY,
+    occurred_at TIMESTAMPTZ,
+    posted_at TIMESTAMPTZ,
+    amount_cents BIGINT NOT NULL,
+    currency TEXT NOT NULL DEFAULT 'USD',
+    merchant TEXT,
+    category TEXT,
+    txn_type TEXT,
+    memo TEXT,
+    hash TEXT NOT NULL,
+    raw_json JSONB NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS chase_transactions_hash_idx
+    ON chase_transactions(hash);
+
+CREATE TABLE IF NOT EXISTS capital_one_transactions (
+    id BIGSERIAL PRIMARY KEY,
+    occurred_at TIMESTAMPTZ,
+    posted_at TIMESTAMPTZ,
+    amount_cents BIGINT NOT NULL,
+    currency TEXT NOT NULL DEFAULT 'USD',
+    merchant TEXT,
+    category TEXT,
+    txn_type TEXT,
+    memo TEXT,
+    hash TEXT NOT NULL,
+    raw_json JSONB NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS capital_one_transactions_hash_idx
+    ON capital_one_transactions(hash);


### PR DESCRIPTION
## Summary
- add separate `chase_transactions` and `capital_one_transactions` tables
- route ingestion into account-specific tables
- add migration and update tests

## Testing
- `./gradlew test`
- `make build-app` *(fails: the server hosted at that remote is unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68b8c50e6bf483258652ccc117997cda