### PR TITLE
Add account references to institution transaction tables

### DIFF
--- a/apps/ingest-service/src/generated/java/org/artificers/jooq/tables/CapitalOneTransactions.java
+++ b/apps/ingest-service/src/generated/java/org/artificers/jooq/tables/CapitalOneTransactions.java
@@ -12,6 +12,7 @@ public class CapitalOneTransactions extends TableImpl<Record> {
     public static final CapitalOneTransactions CAPITAL_ONE_TRANSACTIONS = new CapitalOneTransactions();
 
     public final TableField<Record, Long> ID = createField(DSL.name("id"), SQLDataType.BIGINT.identity(true), this, "");
+    public final TableField<Record, Long> ACCOUNT_ID = createField(DSL.name("account_id"), SQLDataType.BIGINT.nullable(false), this, "");
     public final TableField<Record, OffsetDateTime> OCCURRED_AT = createField(DSL.name("occurred_at"), SQLDataType.TIMESTAMPWITHTIMEZONE, this, "");
     public final TableField<Record, OffsetDateTime> POSTED_AT = createField(DSL.name("posted_at"), SQLDataType.TIMESTAMPWITHTIMEZONE, this, "");
     public final TableField<Record, Long> AMOUNT_CENTS = createField(DSL.name("amount_cents"), SQLDataType.BIGINT.nullable(false), this, "");

--- a/apps/ingest-service/src/generated/java/org/artificers/jooq/tables/ChaseTransactions.java
+++ b/apps/ingest-service/src/generated/java/org/artificers/jooq/tables/ChaseTransactions.java
@@ -12,6 +12,7 @@ public class ChaseTransactions extends TableImpl<Record> {
     public static final ChaseTransactions CHASE_TRANSACTIONS = new ChaseTransactions();
 
     public final TableField<Record, Long> ID = createField(DSL.name("id"), SQLDataType.BIGINT.identity(true), this, "");
+    public final TableField<Record, Long> ACCOUNT_ID = createField(DSL.name("account_id"), SQLDataType.BIGINT.nullable(false), this, "");
     public final TableField<Record, OffsetDateTime> OCCURRED_AT = createField(DSL.name("occurred_at"), SQLDataType.TIMESTAMPWITHTIMEZONE, this, "");
     public final TableField<Record, OffsetDateTime> POSTED_AT = createField(DSL.name("posted_at"), SQLDataType.TIMESTAMPWITHTIMEZONE, this, "");
     public final TableField<Record, Long> AMOUNT_CENTS = createField(DSL.name("amount_cents"), SQLDataType.BIGINT.nullable(false), this, "");

--- a/apps/ingest-service/src/main/java/org/artificers/ingest/IngestService.java
+++ b/apps/ingest-service/src/main/java/org/artificers/ingest/IngestService.java
@@ -101,6 +101,7 @@ public class IngestService {
         }
         try {
             ctx.insertInto(DSL.table(DSL.name(table)))
+                    .set(DSL.field(DSL.name(table, "account_id"), Long.class), account.id())
                     .set(DSL.field(DSL.name(table, "occurred_at"), OffsetDateTime.class), toOffsetDateTime(t.occurredAt()))
                     .set(DSL.field(DSL.name(table, "posted_at"), OffsetDateTime.class), toOffsetDateTime(t.postedAt()))
                     .set(DSL.field(DSL.name(table, "amount_cents"), Long.class), t.amountCents())
@@ -111,7 +112,10 @@ public class IngestService {
                     .set(DSL.field(DSL.name(table, "memo"), String.class), t.memo())
                     .set(DSL.field(DSL.name(table, "hash"), String.class), t.hash())
                     .set(DSL.field(DSL.name(table, "raw_json"), JSONB.class), JSONB.valueOf(t.rawJson()))
-                    .onConflict(DSL.field(DSL.name(table, "hash"), String.class))
+                    .onConflict(
+                            DSL.field(DSL.name(table, "account_id"), Long.class),
+                            DSL.field(DSL.name(table, "hash"), String.class)
+                    )
                     .doNothing()
                     .execute();
         } catch (DataAccessException e) {

--- a/ops/sql/V8__add_account_id.sql
+++ b/ops/sql/V8__add_account_id.sql
@@ -1,0 +1,13 @@
+ALTER TABLE chase_transactions
+    ADD COLUMN account_id BIGINT NOT NULL REFERENCES accounts(id);
+
+ALTER TABLE capital_one_transactions
+    ADD COLUMN account_id BIGINT NOT NULL REFERENCES accounts(id);
+
+DROP INDEX IF EXISTS chase_transactions_hash_idx;
+CREATE UNIQUE INDEX chase_transactions_account_hash_idx
+    ON chase_transactions(account_id, hash);
+
+DROP INDEX IF EXISTS capital_one_transactions_hash_idx;
+CREATE UNIQUE INDEX capital_one_transactions_account_hash_idx
+    ON capital_one_transactions(account_id, hash);


### PR DESCRIPTION
## Summary
- add `account_id` column to institutional transaction tables and unique index per account
- include account id when ingesting transactions
- update tests and regenerate jOOQ models

## Testing
- `./gradlew test`
- `make build-app` *(fails: Failure: the server hosted at that remote is unavailable.)*


------
https://chatgpt.com/codex/tasks/task_e_68b8cd83b0b48325b6a4a14969a4ab38