### PR TITLE
Backfill account IDs in migration

### DIFF
--- a/ops/sql/V8__add_account_id.sql
+++ b/ops/sql/V8__add_account_id.sql
@@ -1,8 +1,25 @@
 ALTER TABLE chase_transactions
-    ADD COLUMN account_id BIGINT NOT NULL REFERENCES accounts(id);
+    ADD COLUMN account_id BIGINT REFERENCES accounts(id);
 
 ALTER TABLE capital_one_transactions
-    ADD COLUMN account_id BIGINT NOT NULL REFERENCES accounts(id);
+    ADD COLUMN account_id BIGINT REFERENCES accounts(id);
+
+-- Backfill existing rows assuming one account per institution
+UPDATE chase_transactions ct
+SET account_id = a.id
+FROM accounts a
+WHERE a.institution = 'ch';
+
+UPDATE capital_one_transactions ct
+SET account_id = a.id
+FROM accounts a
+WHERE a.institution = 'co';
+
+ALTER TABLE chase_transactions
+    ALTER COLUMN account_id SET NOT NULL;
+
+ALTER TABLE capital_one_transactions
+    ALTER COLUMN account_id SET NOT NULL;
 
 DROP INDEX IF EXISTS chase_transactions_hash_idx;
 CREATE UNIQUE INDEX chase_transactions_account_hash_idx


### PR DESCRIPTION
## Summary
- Populate `account_id` on existing Chase and Capital One transaction rows during migration
- Ensure new account-based unique indexes can be created without null violations

## Testing
- `make db-migrate` *(fails: docker: command not found)*
- `cd apps/ingest-service && ./gradlew test`
- `make build-app` *(fails: remote server unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68b8cca32a848325acff16ef9e95e5df