### PR TITLE
Fix ingest to use institution-specific tables

### DIFF
--- a/apps/ingest-service/src/main/java/org/artificers/ingest/IngestService.java
+++ b/apps/ingest-service/src/main/java/org/artificers/ingest/IngestService.java
@@ -119,24 +119,6 @@ public class IngestService {
                     )
                     .doNothing()
                     .execute();
-            ctx.insertInto(DSL.table(DSL.name("transactions")))
-                    .set(DSL.field(DSL.name("transactions", "account_id"), Long.class), account.id())
-                    .set(DSL.field(DSL.name("transactions", "occurred_at"), OffsetDateTime.class), toOffsetDateTime(t.occurredAt()))
-                    .set(DSL.field(DSL.name("transactions", "posted_at"), OffsetDateTime.class), toOffsetDateTime(t.postedAt()))
-                    .set(DSL.field(DSL.name("transactions", "amount_cents"), Long.class), t.amountCents())
-                    .set(DSL.field(DSL.name("transactions", "currency"), String.class), t.currency())
-                    .set(DSL.field(DSL.name("transactions", "merchant"), String.class), t.merchant())
-                    .set(DSL.field(DSL.name("transactions", "category"), String.class), t.category())
-                    .set(DSL.field(DSL.name("transactions", "txn_type"), String.class), t.type())
-                    .set(DSL.field(DSL.name("transactions", "memo"), String.class), t.memo())
-                    .set(DSL.field(DSL.name("transactions", "hash"), String.class), t.hash())
-                    .set(DSL.field(DSL.name("transactions", "raw_json"), JSONB.class), JSONB.valueOf(t.rawJson()))
-                    .onConflict(
-                            DSL.field(DSL.name("transactions", "account_id"), Long.class),
-                            DSL.field(DSL.name("transactions", "hash"), String.class)
-                    )
-                    .doNothing()
-                    .execute();
         } catch (DataAccessException e) {
             throw new TransactionIngestException(t, e);
         }

--- a/apps/ingest-service/src/test/java/org/artificers/ingest/IngestServiceViewTest.java
+++ b/apps/ingest-service/src/test/java/org/artificers/ingest/IngestServiceViewTest.java
@@ -14,24 +14,26 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
-class IngestServiceCanonicalTest {
+class IngestServiceViewTest {
     @ParameterizedTest
-    @CsvSource({"ch,chase_transactions", "co,capital_one_transactions"})
-    void writesToCanonicalTransactions(String institution, String table, @TempDir Path dir) throws Exception {
+    @CsvSource({"ch", "co"})
+    void writesToTransactionsView(String institution, @TempDir Path dir) throws Exception {
         DSLContext dsl = DSL.using("jdbc:h2:mem:test;MODE=PostgreSQL;DATABASE_TO_UPPER=false", "sa", "");
+        dsl.execute("drop view if exists transactions_view");
         dsl.execute("drop table if exists chase_transactions");
         dsl.execute("drop table if exists capital_one_transactions");
         dsl.execute("drop table if exists accounts");
-        dsl.execute("drop table if exists transactions");
 
         dsl.execute("create table accounts (id serial primary key, institution varchar not null, external_id varchar not null, display_name varchar not null, created_at timestamp, updated_at timestamp)");
         dsl.execute("create unique index on accounts(institution, external_id)");
 
-        dsl.execute("create table " + table + " (id serial primary key, account_id bigint not null references accounts(id), occurred_at timestamp, posted_at timestamp, amount_cents bigint not null, currency varchar not null, merchant varchar, category varchar, txn_type varchar, memo varchar, hash varchar not null, raw_json clob)");
-        dsl.execute("create unique index on " + table + "(account_id, hash)");
+        dsl.execute("create table chase_transactions (id serial primary key, account_id bigint not null references accounts(id), occurred_at timestamp, posted_at timestamp, amount_cents bigint not null, currency varchar not null, merchant varchar, category varchar, txn_type varchar, memo varchar, hash varchar not null, raw_json clob)");
+        dsl.execute("create unique index on chase_transactions(account_id, hash)");
 
-        dsl.execute("create table transactions (id serial primary key, account_id bigint not null, occurred_at timestamp, posted_at timestamp, amount_cents bigint not null, currency varchar not null, merchant varchar, category varchar, txn_type varchar, memo varchar, hash varchar not null, raw_json clob)");
-        dsl.execute("create unique index on transactions(account_id, hash)");
+        dsl.execute("create table capital_one_transactions (id serial primary key, account_id bigint not null references accounts(id), occurred_at timestamp, posted_at timestamp, amount_cents bigint not null, currency varchar not null, merchant varchar, category varchar, txn_type varchar, memo varchar, hash varchar not null, raw_json clob)");
+        dsl.execute("create unique index on capital_one_transactions(account_id, hash)");
+
+        dsl.execute("create view transactions_view as select * from chase_transactions union all select * from capital_one_transactions");
 
         AccountResolver resolver = new AccountResolver(dsl);
         TransactionCsvReader reader = mock(TransactionCsvReader.class);
@@ -44,7 +46,7 @@ class IngestServiceCanonicalTest {
         boolean ok = service.ingestFile(dir.resolve(institution + "1234.csv"), institution + "1234");
 
         assertThat(ok).isTrue();
-        assertThat(dsl.fetchCount(DSL.table("transactions"))).isEqualTo(1);
+        assertThat(dsl.fetchCount(DSL.table("transactions_view"))).isEqualTo(1);
     }
 }
 


### PR DESCRIPTION
## Summary
- remove insert into deprecated transactions table
- add test ensuring transactions view reflects ingested rows

## Testing
- `./gradlew test`
- `make build-app` *(fails: Failure: the server hosted at that remote is unavailable.)*

------
https://chatgpt.com/codex/tasks/task_e_68b8f39a2bec8325af7d5e1fb4da62b1