### PR TITLE
Skip materialized view refresh when absent

### DIFF
--- a/apps/ingest-service/src/main/java/org/artificers/ingest/IngestService.java
+++ b/apps/ingest-service/src/main/java/org/artificers/ingest/IngestService.java
@@ -130,8 +130,15 @@ public class IngestService {
 
     private void refreshMaterializedView() {
         try {
-            dsl.execute("REFRESH MATERIALIZED VIEW transactions_view");
-        } catch (DataAccessException e) {
+            boolean exists = dsl.fetchExists(
+                    DSL.selectOne()
+                            .from("pg_matviews")
+                            .where(DSL.field("matviewname").eq("transactions_view"))
+            );
+            if (exists) {
+                dsl.execute("REFRESH MATERIALIZED VIEW transactions_view");
+            }
+        } catch (Exception e) {
             log.debug("Skipping materialized view refresh: {}", e.getMessage());
         }
     }


### PR DESCRIPTION
## Summary
- Avoid BadSqlGrammarException by checking for `transactions_view` in `pg_matviews` before attempting refresh.

## Testing
- `make deps` *(fails: No rule to make target 'deps')*
- `cd apps/ingest-service && ./gradlew test`
- `make build-app` *(fails: the server hosted at that remote is unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68b8fcfe35f8832589f66e4516216902