### PR TITLE
test: verify transaction inserts and view rebuild

### DIFF
--- a/apps/ingest-service/src/test/java/org/artificers/ingest/AccountCreationIntegrationTest.java
+++ b/apps/ingest-service/src/test/java/org/artificers/ingest/AccountCreationIntegrationTest.java
@@ -20,6 +20,8 @@ public class AccountCreationIntegrationTest {
     @BeforeEach
     void setup() {
         dsl = DSL.using("jdbc:h2:mem:test;MODE=PostgreSQL;DATABASE_TO_UPPER=false", "sa", "");
+        dsl.execute("drop view if exists transactions_view");
+        dsl.execute("drop table if exists transactions");
         dsl.execute("drop table if exists accounts");
         dsl.execute("create table accounts (id serial primary key, institution varchar not null, external_id varchar not null, display_name varchar not null, created_at timestamp, updated_at timestamp)");
         dsl.execute("create unique index on accounts(institution, external_id)");

--- a/apps/ingest-service/src/test/java/org/artificers/ingest/AccountResolverTest.java
+++ b/apps/ingest-service/src/test/java/org/artificers/ingest/AccountResolverTest.java
@@ -12,6 +12,8 @@ import static org.junit.jupiter.api.Assertions.*;
 public class AccountResolverTest {
     private DSLContext initDsl() {
         DSLContext dsl = DSL.using("jdbc:h2:mem:test;MODE=PostgreSQL;DATABASE_TO_UPPER=false", "sa", "");
+        dsl.execute("drop view if exists transactions_view");
+        dsl.execute("drop table if exists transactions");
         dsl.execute("drop table if exists accounts");
         dsl.execute("create table accounts (id serial primary key, institution varchar not null, external_id varchar not null, display_name varchar not null, created_at timestamp, updated_at timestamp)");
         dsl.execute("create unique index on accounts(institution, external_id)");

--- a/apps/ingest-service/src/test/java/org/artificers/ingest/ConfigurableCsvReaderTest.java
+++ b/apps/ingest-service/src/test/java/org/artificers/ingest/ConfigurableCsvReaderTest.java
@@ -59,4 +59,24 @@ class ConfigurableCsvReaderTest {
         assertEquals(Instant.parse("2025-04-28T00:00:00Z"), t1.occurredAt());
         assertTrue(t1.rawJson().contains("\"card_no\":\"1828\""));
     }
+
+    @Test
+    void parsesIntAmounts() throws Exception {
+        String mapping = "{" +
+                "\"institution\":\"xx\"," +
+                "\"fields\":{" +
+                "\"date\":{\"target\":\"occurred_at\",\"type\":\"timestamp\"}," +
+                "\"debit\":{\"target\":\"amount_cents\",\"type\":\"int\"}," +
+                "\"credit\":{\"target\":\"amount_cents\",\"type\":\"int\"}" +
+                "}}";
+        ConfigurableCsvReader.Mapping m = new ObjectMapper().readValue(mapping, ConfigurableCsvReader.Mapping.class);
+        ConfigurableCsvReader reader = new ConfigurableCsvReader(m);
+        String csv = "date,debit,credit\n" +
+                "2025-04-30,100,0\n" +
+                "2025-04-29,0,200\n";
+        List<TransactionRecord> txs = reader.read(null, new StringReader(csv), "1");
+        assertEquals(2, txs.size());
+        assertEquals(-100, txs.get(0).amountCents());
+        assertEquals(200, txs.get(1).amountCents());
+    }
 }

--- a/apps/ingest-service/src/test/java/org/artificers/ingest/IngestServiceTransactionTest.java
+++ b/apps/ingest-service/src/test/java/org/artificers/ingest/IngestServiceTransactionTest.java
@@ -19,6 +19,7 @@ class IngestServiceTransactionTest {
     @CsvSource({"ch", "co"})
     void ignoresDuplicateTransactions(String institution, @TempDir Path dir) throws Exception {
         DSLContext dsl = DSL.using("jdbc:h2:mem:test;MODE=PostgreSQL;DATABASE_TO_UPPER=false", "sa", "");
+        dsl.execute("drop view if exists transactions_view");
         dsl.execute("drop table if exists transactions");
         dsl.execute("drop table if exists accounts");
         dsl.execute("create table accounts (id serial primary key, institution varchar not null, external_id varchar not null, display_name varchar not null, created_at timestamp, updated_at timestamp)");

--- a/apps/ingest-service/src/test/java/org/artificers/ingest/IngestServiceViewTest.java
+++ b/apps/ingest-service/src/test/java/org/artificers/ingest/IngestServiceViewTest.java
@@ -1,48 +1,89 @@
 package org.artificers.ingest;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.jooq.DSLContext;
 import org.jooq.impl.DSL;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-import org.junit.jupiter.api.io.TempDir;
 
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
 
 class IngestServiceViewTest {
+    private ConfigurableCsvReader reader(String institution) throws Exception {
+        try (InputStream in = getClass().getResourceAsStream("/mappings/" + institution + ".json")) {
+            ConfigurableCsvReader.Mapping mapping =
+                    new ObjectMapper().readValue(in, ConfigurableCsvReader.Mapping.class);
+            return new ConfigurableCsvReader(mapping);
+        }
+    }
+
+    private Path copyResource(String resource, Path dir) throws Exception {
+        Path file = dir.resolve(resource.substring(resource.lastIndexOf('/') + 1));
+        try (InputStream in = getClass().getResourceAsStream(resource)) {
+            Files.copy(in, file, StandardCopyOption.REPLACE_EXISTING);
+        }
+        return file;
+    }
+
     @ParameterizedTest
-    @CsvSource({"ch", "co"})
-    void writesToTransactionsView(String institution, @TempDir Path dir) throws Exception {
+    @CsvSource({
+            "ch,ch1234-example.csv,1234,0",
+            "co,co1828-example.csv,1828,58588"
+    })
+    void ingestsTransactionsAndRebuildsView(String institution, String fileName, String externalId,
+                                            long sum, @TempDir Path dir) throws Exception {
         DSLContext dsl = DSL.using("jdbc:h2:mem:test;MODE=PostgreSQL;DATABASE_TO_UPPER=false", "sa", "");
+
         dsl.execute("drop view if exists transactions_view");
         dsl.execute("drop table if exists transactions");
         dsl.execute("drop table if exists accounts");
 
-        dsl.execute("create table accounts (id serial primary key, institution varchar not null, external_id varchar not null, display_name varchar not null, created_at timestamp, updated_at timestamp)");
+        dsl.execute("create table accounts (id serial primary key, institution varchar not null, " +
+                "external_id varchar not null, display_name varchar not null, created_at timestamp, updated_at timestamp)");
         dsl.execute("create unique index on accounts(institution, external_id)");
-
-        dsl.execute("create table transactions (id serial primary key, account_id bigint not null references accounts(id), occurred_at timestamp, posted_at timestamp, amount_cents bigint not null, currency varchar not null, merchant varchar, category varchar, txn_type varchar, memo varchar, hash varchar not null, raw_json clob)");
+        dsl.execute("create table transactions (id serial primary key, account_id bigint not null references accounts(id), " +
+                "occurred_at timestamp, posted_at timestamp, amount_cents bigint not null, currency varchar not null, merchant varchar, " +
+                "category varchar, txn_type varchar, memo varchar, hash varchar not null, raw_json clob)");
         dsl.execute("create unique index on transactions(account_id, hash)");
 
-        dsl.execute("create view transactions_view as select t.*, a.institution from transactions t join accounts a on a.id = t.account_id");
-
+        ConfigurableCsvReader reader = reader(institution);
         AccountResolver resolver = new AccountResolver(dsl);
-        TransactionCsvReader reader = mock(TransactionCsvReader.class);
-        when(reader.institution()).thenReturn(institution);
-        TransactionRecord t1 = new GenericTransaction("a", null, null, 100, "USD", "m", "c", null, null, "h1", "{}");
-        when(reader.read(any(), any(), eq("1234"))).thenReturn(List.of(t1));
-
-        Files.writeString(dir.resolve(institution + "1234.csv"), "id,amount\n1,10");
         IngestService service = new IngestService(dsl, resolver, List.of(reader));
-        boolean ok = service.ingestFile(dir.resolve(institution + "1234.csv"), institution + "1234");
+
+        Path file = copyResource("/examples/" + fileName, dir);
+        boolean ok = service.ingestFile(file, institution + externalId);
 
         assertThat(ok).isTrue();
-        assertThat(dsl.fetchCount(DSL.table("transactions_view"))).isEqualTo(1);
+        assertThat(
+                dsl.fetchCount(
+                        DSL.table("transactions"),
+                        DSL.field("amount_cents").ne(0).or(DSL.field("merchant").isNotNull())
+                )
+        ).isEqualTo(2);
+        long total = dsl.select(DSL.coalesce(DSL.sum(DSL.field("amount_cents", Long.class)), 0L))
+                .from("transactions")
+                .fetchOne(0, Long.class);
+        assertThat(total).isEqualTo(sum);
+
+        dsl.execute("create view transactions_view as select t.*, a.institution from transactions t " +
+                "join accounts a on a.id = t.account_id");
+        assertThat(
+                dsl.fetchCount(
+                        DSL.table("transactions_view"),
+                        DSL.field("amount_cents").ne(0).or(DSL.field("merchant").isNotNull())
+                )
+        ).isEqualTo(2);
+        long viewTotal = dsl.select(DSL.coalesce(DSL.sum(DSL.field("amount_cents", Long.class)), 0L))
+                .from("transactions_view")
+                .fetchOne(0, Long.class);
+        assertThat(viewTotal).isEqualTo(sum);
     }
 }
 

--- a/apps/ingest-service/src/test/java/org/artificers/ingest/cli/NewAccountCliTest.java
+++ b/apps/ingest-service/src/test/java/org/artificers/ingest/cli/NewAccountCliTest.java
@@ -8,6 +8,8 @@ import java.nio.file.Path;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import org.jooq.DSLContext;
+import org.jooq.impl.DSL;
 
 class NewAccountCliTest {
     @Test
@@ -17,5 +19,27 @@ class NewAccountCliTest {
         assertThat(Files.exists(file)).isTrue();
         assertThatThrownBy(() -> NewAccountCli.copyTemplate(dir, "xx", false))
                 .isInstanceOf(IOException.class);
+    }
+
+    @Test
+    void copyTemplateForceOverwrites() throws IOException {
+        Path dir = Files.createTempDirectory("ingest-test");
+        Path file = NewAccountCli.copyTemplate(dir, "xx", false);
+        Files.writeString(file, "custom");
+        Path file2 = NewAccountCli.copyTemplate(dir, "xx", true);
+        assertThat(Files.exists(file2)).isTrue();
+    }
+
+    @Test
+    void insertAccountIsIdempotent() {
+        DSLContext dsl = DSL.using("jdbc:h2:mem:test;MODE=PostgreSQL;DATABASE_TO_UPPER=false", "sa", "");
+        dsl.execute("drop view if exists transactions_view");
+        dsl.execute("drop table if exists transactions");
+        dsl.execute("drop table if exists accounts");
+        dsl.execute("create table accounts (id serial primary key, institution varchar not null, external_id varchar not null, display_name varchar not null, created_at timestamp, updated_at timestamp)");
+        long id1 = NewAccountCli.insertAccount(dsl, "ch", "1234", "test");
+        long id2 = NewAccountCli.insertAccount(dsl, "ch", "1234", "ignored");
+        assertThat(id1).isEqualTo(id2);
+        assertThat(dsl.fetchCount(DSL.table("accounts"))).isEqualTo(1);
     }
 }


### PR DESCRIPTION
## Summary
- cover CSV mappings and examples in integration test that rebuilds `transactions_view`
- validate integer parsing in `ConfigurableCsvReader`
- exercise CLI account creation and template overwriting

## Testing
- `make deps` *(fails: No rule to make target 'deps')*
- `cd apps/ingest-service && ./gradlew test`
- `make build-app` *(fails: Failure: the server hosted at that remote is unavailable.)*

------
https://chatgpt.com/codex/tasks/task_e_68ba03c87cc483258736574934cf473d