### PR TITLE
feat: separate mapping file loading

### DIFF
--- a/apps/ingest-service/src/main/java/org/artificers/ingest/MappingFileLocator.java
+++ b/apps/ingest-service/src/main/java/org/artificers/ingest/MappingFileLocator.java
@@ -1,0 +1,38 @@
+package org.artificers.ingest;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.ResourcePatternResolver;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Locates mapping definition files on the classpath and converts them to
+ * {@link ConfigurableCsvReader.Mapping} objects.
+ */
+@Component
+public class MappingFileLocator {
+    private final ObjectMapper mapper;
+    private final ResourcePatternResolver resolver;
+
+    public MappingFileLocator(ObjectMapper mapper, ResourcePatternResolver resolver) {
+        this.mapper = mapper;
+        this.resolver = resolver;
+    }
+
+    /**
+     * Find all JSON mapping files under {@code classpath:mappings}.
+     */
+    public List<ConfigurableCsvReader.Mapping> locate() throws IOException {
+        Resource[] resources = resolver.getResources("classpath:mappings/*.json");
+        List<ConfigurableCsvReader.Mapping> mappings = new ArrayList<>();
+        for (Resource r : resources) {
+            mappings.add(mapper.readValue(r.getInputStream(), ConfigurableCsvReader.Mapping.class));
+        }
+        return mappings;
+    }
+}
+

--- a/apps/ingest-service/src/test/java/org/artificers/ingest/CsvMappingLoaderTest.java
+++ b/apps/ingest-service/src/test/java/org/artificers/ingest/CsvMappingLoaderTest.java
@@ -1,0 +1,34 @@
+package org.artificers.ingest;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.context.support.GenericApplicationContext;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CsvMappingLoaderTest {
+    @Test
+    void registersBeansForEachMapping() throws Exception {
+        ConfigurableCsvReader.Mapping m1 = new ConfigurableCsvReader.Mapping("x1", Map.of());
+        ConfigurableCsvReader.Mapping m2 = new ConfigurableCsvReader.Mapping("x2", Map.of());
+        MappingFileLocator locator = new MappingFileLocator(null, null) {
+            @Override
+            public List<ConfigurableCsvReader.Mapping> locate() {
+                return List.of(m1, m2);
+            }
+        };
+        CsvMappingLoader loader = new CsvMappingLoader(locator);
+        GenericApplicationContext context = new GenericApplicationContext();
+        loader.postProcessBeanDefinitionRegistry(context);
+        context.refresh();
+
+        TransactionCsvReader r1 = context.getBean("x1CsvReader", TransactionCsvReader.class);
+        TransactionCsvReader r2 = context.getBean("x2CsvReader", TransactionCsvReader.class);
+        assertEquals("x1", r1.institution());
+        assertEquals("x2", r2.institution());
+        context.close();
+    }
+}
+

--- a/apps/ingest-service/src/test/java/org/artificers/ingest/MappingFileLocatorTest.java
+++ b/apps/ingest-service/src/test/java/org/artificers/ingest/MappingFileLocatorTest.java
@@ -1,0 +1,20 @@
+package org.artificers.ingest;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MappingFileLocatorTest {
+    @Test
+    void locatesJsonMappings() throws Exception {
+        MappingFileLocator locator = new MappingFileLocator(new ObjectMapper(), new PathMatchingResourcePatternResolver());
+        List<ConfigurableCsvReader.Mapping> mappings = locator.locate();
+        assertTrue(mappings.stream().anyMatch(m -> "co".equals(m.institution())));
+        assertTrue(mappings.stream().anyMatch(m -> "ch".equals(m.institution())));
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `MappingFileLocator` to load CSV reader mappings from JSON files
- refactor `CsvMappingLoader` to register readers using the locator
- add unit tests for `MappingFileLocator` and `CsvMappingLoader`

## Testing
- `make deps` *(fails: No rule to make target 'deps')*
- `cd apps/ingest-service && ./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68ba275639888325a30717ffe08a11de