### PR TITLE
Fix CsvMappingLoader bean initialization

### DIFF
--- a/apps/ingest-service/src/main/java/org/artificers/ingest/CsvMappingLoader.java
+++ b/apps/ingest-service/src/main/java/org/artificers/ingest/CsvMappingLoader.java
@@ -6,17 +6,17 @@ import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.BeanDefinitionRegistryPostProcessor;
 import org.springframework.beans.factory.BeanDefinitionStoreException;
 import org.springframework.context.support.GenericApplicationContext;
-import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 import java.util.List;
 
 /**
- * Loads CSV reader mappings from JSON files and registers a {@link TransactionCsvReader}
- * bean for each mapping. Dependencies are injected so that the loader can be
- * tested in isolation and to follow constructor-based immutability.
+ * BeanDefinitionRegistryPostProcessor that loads CSV reader mappings from JSON
+ * files and registers a {@link TransactionCsvReader} bean for each mapping. It
+ * is registered via a configuration class to enable constructor-based
+ * dependency injection even though BeanDefinitionRegistryPostProcessor
+ * instances are created very early in the Spring lifecycle.
  */
-@Component
 public class CsvMappingLoader implements BeanDefinitionRegistryPostProcessor {
     private final MappingFileLocator locator;
 

--- a/apps/ingest-service/src/main/java/org/artificers/ingest/CsvMappingLoaderConfiguration.java
+++ b/apps/ingest-service/src/main/java/org/artificers/ingest/CsvMappingLoaderConfiguration.java
@@ -1,0 +1,16 @@
+package org.artificers.ingest;
+
+import org.springframework.beans.factory.support.BeanDefinitionRegistryPostProcessor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Registers {@link CsvMappingLoader} with constructor-based dependency injection.
+ */
+@Configuration
+class CsvMappingLoaderConfiguration {
+    @Bean
+    static BeanDefinitionRegistryPostProcessor csvMappingLoader(MappingFileLocator locator) {
+        return new CsvMappingLoader(locator);
+    }
+}


### PR DESCRIPTION
## Summary
- Register CsvMappingLoader via configuration to allow constructor-based injection
- Remove direct @Component usage from CsvMappingLoader

## Testing
- `make deps` (fails: No rule to make target 'deps')
- `cd apps/ingest-service && ./gradlew test`
- `make build-app` (fails: server hosted at buf remote unavailable)

------
https://chatgpt.com/codex/tasks/task_e_68ba4be842b88325bde1b3d912aa9de8