### PR TITLE
Fix MappingFileLocator bean initialization

### DIFF
--- a/apps/ingest-service/src/main/java/org/artificers/ingest/CsvMappingLoaderConfiguration.java
+++ b/apps/ingest-service/src/main/java/org/artificers/ingest/CsvMappingLoaderConfiguration.java
@@ -3,12 +3,20 @@ package org.artificers.ingest;
 import org.springframework.beans.factory.support.BeanDefinitionRegistryPostProcessor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+import org.springframework.core.io.support.ResourcePatternResolver;
 
 /**
  * Registers {@link CsvMappingLoader} with constructor-based dependency injection.
  */
 @Configuration
 class CsvMappingLoaderConfiguration {
+    @Bean
+    ResourcePatternResolver resourcePatternResolver(ResourceLoader loader) {
+        return new PathMatchingResourcePatternResolver(loader);
+    }
+
     @Bean
     static BeanDefinitionRegistryPostProcessor csvMappingLoader(MappingFileLocator locator) {
         return new CsvMappingLoader(locator);


### PR DESCRIPTION
## Summary
- Add ResourcePatternResolver bean so MappingFileLocator can be constructed

## Testing
- `cd apps/ingest-service && ./gradlew test`
- `make build-app` *(fails: the server hosted at that remote is unavailable)*
- `cd apps/ingest-service && ./gradlew bootJar`


------
https://chatgpt.com/codex/tasks/task_e_68ba5f76a8b08325a3a8b59a45aaedda