### PR TITLE
refactor: inject config and drop spring wiring

### DIFF
--- a/apps/ingest-service/build.gradle
+++ b/apps/ingest-service/build.gradle
@@ -13,9 +13,6 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot:3.2.0'
-    implementation 'org.springframework.boot:spring-boot-autoconfigure:3.2.0'
-    implementation 'org.springframework:spring-context:6.1.1'
     implementation 'org.springframework:spring-web:6.1.1'
     implementation 'org.flywaydb:flyway-core:9.22.3'
     implementation 'org.jooq:jooq:3.18.5'

--- a/apps/ingest-service/src/main/java/org/artificers/ingest/DataModule.java
+++ b/apps/ingest-service/src/main/java/org/artificers/ingest/DataModule.java
@@ -7,17 +7,22 @@ import javax.inject.Singleton;
 import org.jooq.DSLContext;
 import org.jooq.SQLDialect;
 import org.jooq.impl.DSL;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Module providing database access objects. */
 @Module
 public interface DataModule {
+    Logger LOG = LoggerFactory.getLogger(DataModule.class);
+
     @Provides
     @Singleton
-    static HikariDataSource dataSource() {
+    static HikariDataSource dataSource(DbConfig cfg) {
+        LOG.info("Initializing datasource with url={} user={}", IngestApp.sanitize(cfg.url()), cfg.user());
         HikariDataSource ds = new HikariDataSource();
-        ds.setJdbcUrl(JdbcUrl.from(System.getenv("DB_URL")));
-        ds.setUsername(System.getenv("DB_USER"));
-        ds.setPassword(System.getenv("DB_PASSWORD"));
+        ds.setJdbcUrl(JdbcUrl.from(cfg.url()));
+        ds.setUsername(cfg.user());
+        ds.setPassword(cfg.password());
         return ds;
     }
 

--- a/apps/ingest-service/src/main/java/org/artificers/ingest/DbConfig.java
+++ b/apps/ingest-service/src/main/java/org/artificers/ingest/DbConfig.java
@@ -1,0 +1,4 @@
+package org.artificers.ingest;
+
+/** Immutable database configuration. */
+public record DbConfig(String url, String user, String password) {}

--- a/apps/ingest-service/src/main/java/org/artificers/ingest/DirectoryWatchService.java
+++ b/apps/ingest-service/src/main/java/org/artificers/ingest/DirectoryWatchService.java
@@ -20,9 +20,9 @@ public class DirectoryWatchService implements AutoCloseable {
     private WatchService watchService;
     private static final Pattern FILE_PATTERN = Pattern.compile("^([a-zA-Z]+\\d{4}).*\\.csv$");
 
-    public DirectoryWatchService(IngestService ingestService, String dir) {
+    public DirectoryWatchService(IngestService ingestService, Path dir) {
         this.ingestService = ingestService;
-        this.directory = Paths.get(dir).toAbsolutePath();
+        this.directory = dir.toAbsolutePath();
         this.executor = Executors.newSingleThreadExecutor(r -> {
             Thread t = new Thread(r);
             t.setDaemon(true);

--- a/apps/ingest-service/src/main/java/org/artificers/ingest/IngestComponent.java
+++ b/apps/ingest-service/src/main/java/org/artificers/ingest/IngestComponent.java
@@ -1,5 +1,6 @@
 package org.artificers.ingest;
 
+import dagger.BindsInstance;
 import dagger.Component;
 import javax.inject.Singleton;
 import org.artificers.ingest.cli.NewAccountCli;
@@ -11,4 +12,11 @@ public interface IngestComponent {
     IngestService ingestService();
     DirectoryWatchService directoryWatchService();
     NewAccountCli newAccountCli();
+
+    @Component.Builder
+    interface Builder {
+        @BindsInstance Builder dbConfig(DbConfig cfg);
+        @BindsInstance Builder ingestConfig(IngestConfig cfg);
+        IngestComponent build();
+    }
 }

--- a/apps/ingest-service/src/main/java/org/artificers/ingest/IngestConfig.java
+++ b/apps/ingest-service/src/main/java/org/artificers/ingest/IngestConfig.java
@@ -1,0 +1,6 @@
+package org.artificers.ingest;
+
+import java.nio.file.Path;
+
+/** Immutable application paths configuration. */
+public record IngestConfig(Path ingestDir, Path configDir) {}

--- a/apps/ingest-service/src/main/java/org/artificers/ingest/ServiceModule.java
+++ b/apps/ingest-service/src/main/java/org/artificers/ingest/ServiceModule.java
@@ -3,8 +3,6 @@ package org.artificers.ingest;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dagger.Module;
 import dagger.Provides;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Set;
 import javax.inject.Singleton;
 import org.artificers.ingest.cli.NewAccountCli;
@@ -33,16 +31,13 @@ public interface ServiceModule {
 
     @Provides
     @Singleton
-    static DirectoryWatchService directoryWatchService(IngestService service) {
-        String dir = System.getenv().getOrDefault("INGEST_DIR", "storage/incoming");
-        return new DirectoryWatchService(service, dir);
+    static DirectoryWatchService directoryWatchService(IngestService service, IngestConfig cfg) {
+        return new DirectoryWatchService(service, cfg.ingestDir());
     }
 
     @Provides
     @Singleton
-    static NewAccountCli newAccountCli(DSLContext dsl) {
-        Path configDir = Paths.get(System.getenv().getOrDefault("INGEST_CONFIG_DIR",
-                System.getProperty("user.home") + "/.config/ingest"));
-        return new NewAccountCli(dsl, configDir);
+    static NewAccountCli newAccountCli(DSLContext dsl, IngestConfig cfg) {
+        return new NewAccountCli(dsl, cfg.configDir());
     }
 }

--- a/apps/ingest-service/src/test/java/org/artificers/ingest/DirectoryWatchServiceIntegrationTest.java
+++ b/apps/ingest-service/src/test/java/org/artificers/ingest/DirectoryWatchServiceIntegrationTest.java
@@ -26,7 +26,7 @@ class DirectoryWatchServiceIntegrationTest {
     void ingestsAndMovesNewCsvFiles(@TempDir Path dir) throws Exception {
         IngestService ingestService = mock(IngestService.class);
         when(ingestService.ingestFile(any(), any())).thenReturn(true);
-        watcher = new DirectoryWatchService(ingestService, dir.toString());
+        watcher = new DirectoryWatchService(ingestService, dir);
         watcher.start();
 
         Path file = dir.resolve("ch1234-example.csv");
@@ -45,7 +45,7 @@ class DirectoryWatchServiceIntegrationTest {
     void movesFailedFilesAndContinuesWatching(@TempDir Path dir) throws Exception {
         IngestService ingestService = mock(IngestService.class);
         when(ingestService.ingestFile(any(), any())).thenReturn(false, true);
-        watcher = new DirectoryWatchService(ingestService, dir.toString());
+        watcher = new DirectoryWatchService(ingestService, dir);
         watcher.start();
 
         Path bad = dir.resolve("ch1234-bad.csv");
@@ -74,7 +74,7 @@ class DirectoryWatchServiceIntegrationTest {
         Path file = dir.resolve("ch1234-existing.csv");
         Files.writeString(file, "id,amount\n1,10");
 
-        watcher = new DirectoryWatchService(ingestService, dir.toString());
+        watcher = new DirectoryWatchService(ingestService, dir);
         watcher.start();
 
         Path processed = dir.resolve("processed").resolve("ch1234-existing.csv");

--- a/apps/ingest-service/src/test/java/org/artificers/ingest/IngestAppTest.java
+++ b/apps/ingest-service/src/test/java/org/artificers/ingest/IngestAppTest.java
@@ -15,8 +15,9 @@ class IngestAppTest {
         IngestService service = mock(IngestService.class);
         when(service.ingestFile(any(), any())).thenReturn(true);
         DirectoryWatchService watch = mock(DirectoryWatchService.class);
+        IngestConfig cfg = new IngestConfig(Path.of("storage/incoming"), Path.of("cfg"));
 
-        int code = new CommandLine(new IngestApp(service, watch)).execute("--file=/tmp/ch1234.csv");
+        int code = new CommandLine(new IngestApp(service, watch, cfg)).execute("--file=/tmp/ch1234.csv");
 
         verify(service).ingestFile(Path.of("/tmp/ch1234.csv"), "ch1234");
         assertThat(code).isZero();
@@ -26,8 +27,9 @@ class IngestAppTest {
     void scansDirectoryWhenModeScanWithInput() throws Exception {
         IngestService service = mock(IngestService.class);
         DirectoryWatchService watch = mock(DirectoryWatchService.class);
+        IngestConfig cfg = new IngestConfig(Path.of("storage/incoming"), Path.of("cfg"));
 
-        int code = new CommandLine(new IngestApp(service, watch)).execute("--mode=scan", "--input=/tmp/in");
+        int code = new CommandLine(new IngestApp(service, watch, cfg)).execute("--mode=scan", "--input=/tmp/in");
 
         verify(service).scanAndIngest(Path.of("/tmp/in"));
         assertThat(code).isZero();
@@ -37,8 +39,9 @@ class IngestAppTest {
     void scansDefaultDirectoryWhenInputMissing() throws Exception {
         IngestService service = mock(IngestService.class);
         DirectoryWatchService watch = mock(DirectoryWatchService.class);
+        IngestConfig cfg = new IngestConfig(Path.of("storage/incoming"), Path.of("cfg"));
 
-        int code = new CommandLine(new IngestApp(service, watch)).execute("--mode=scan");
+        int code = new CommandLine(new IngestApp(service, watch, cfg)).execute("--mode=scan");
 
         verify(service).scanAndIngest(Path.of("storage/incoming"));
         assertThat(code).isZero();


### PR DESCRIPTION
## Summary
- replace Spring config with Dagger-bound `DbConfig` and `IngestConfig`
- refactor `DirectoryWatchService` to take `Path` and manage lifecycle via `start/stop`
- simplify mapping lookup to classpath or provided `Path`

## Testing
- `make deps` *(fails: No rule to make target 'deps')*
- `cd apps/ingest-service && ./gradlew test`
- `make build-app` *(fails: server hosted at remote is unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68bb176853c883258cd1a6f5ee762921