### PR TITLE
Refactor CSV reader loading into module

### DIFF
--- a/apps/ingest-service/src/main/java/org/artificers/ingest/IngestService.java
+++ b/apps/ingest-service/src/main/java/org/artificers/ingest/IngestService.java
@@ -17,6 +17,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class IngestService {
@@ -26,7 +27,7 @@ public class IngestService {
     private final AccountResolver accountResolver;
     private final Map<String, TransactionCsvReader> readers;
 
-    public IngestService(DSLContext dsl, AccountResolver accountResolver, List<TransactionCsvReader> readers) {
+    public IngestService(DSLContext dsl, AccountResolver accountResolver, Set<TransactionCsvReader> readers) {
         this.dsl = dsl;
         this.accountResolver = accountResolver;
         this.readers = readers.stream().collect(Collectors.toMap(TransactionCsvReader::institution, r -> r));

--- a/apps/ingest-service/src/main/java/org/artificers/ingest/ServiceModule.java
+++ b/apps/ingest-service/src/main/java/org/artificers/ingest/ServiceModule.java
@@ -26,7 +26,7 @@ public interface ServiceModule {
     @Provides
     @Singleton
     static IngestService ingestService(DSLContext dsl, AccountResolver resolver, Set<TransactionCsvReader> readers) {
-        return new IngestService(dsl, resolver, readers.stream().toList());
+        return new IngestService(dsl, resolver, readers);
     }
 
     @Provides

--- a/apps/ingest-service/src/test/java/org/artificers/ingest/IngestServiceRawJsonTest.java
+++ b/apps/ingest-service/src/test/java/org/artificers/ingest/IngestServiceRawJsonTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Method;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -27,7 +28,7 @@ class IngestServiceRawJsonTest {
             }
         };
         DSLContext dsl = DSL.using(new MockConnection(provider), SQLDialect.POSTGRES);
-        IngestService service = new IngestService(dsl, null, List.of());
+        IngestService service = new IngestService(dsl, null, Set.of());
         TransactionRecord tx = new GenericTransaction("a", null, null, 100, "USD", "m", "c", null, null, "h", "{}");
         ResolvedAccount account = new ResolvedAccount(1, "co", "a");
 

--- a/apps/ingest-service/src/test/java/org/artificers/ingest/IngestServiceTest.java
+++ b/apps/ingest-service/src/test/java/org/artificers/ingest/IngestServiceTest.java
@@ -15,6 +15,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.List;
+import java.util.Set;
 
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -38,7 +39,7 @@ class IngestServiceTest {
         copyResource("ch1234-example.csv", dir.resolve("ch1234-example.csv"));
         copyResource("co1828-example.csv", dir.resolve("co1828-example.csv"));
 
-        IngestService service = new IngestService(dsl, resolver, List.of(chReader, coReader));
+        IngestService service = new IngestService(dsl, resolver, Set.of(chReader, coReader));
         service.scanAndIngest(dir);
 
         verify(chReader).read(eq(dir.resolve("ch1234-example.csv")), any(), eq("1234"));

--- a/apps/ingest-service/src/test/java/org/artificers/ingest/IngestServiceTransactionTest.java
+++ b/apps/ingest-service/src/test/java/org/artificers/ingest/IngestServiceTransactionTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.io.TempDir;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.*;
@@ -35,7 +36,7 @@ class IngestServiceTransactionTest {
         when(reader.read(any(), any(), eq("1234"))).thenReturn(List.of(t1, t2));
 
         Files.writeString(dir.resolve(institution + "1234.csv"), "id,amount\n1,10");
-        IngestService service = new IngestService(dsl, resolver, List.of(reader));
+        IngestService service = new IngestService(dsl, resolver, Set.of(reader));
         boolean ok = service.ingestFile(dir.resolve(institution + "1234.csv"), institution + "1234");
 
         assertThat(ok).isTrue();

--- a/apps/ingest-service/src/test/java/org/artificers/ingest/IngestServiceViewTest.java
+++ b/apps/ingest-service/src/test/java/org/artificers/ingest/IngestServiceViewTest.java
@@ -12,6 +12,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.List;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -55,7 +56,7 @@ class IngestServiceViewTest {
 
         ConfigurableCsvReader reader = reader(institution);
         AccountResolver resolver = new AccountResolver(dsl);
-        IngestService service = new IngestService(dsl, resolver, List.of(reader));
+        IngestService service = new IngestService(dsl, resolver, Set.of(reader));
 
         Path file = copyResource("/examples/" + fileName, dir);
         boolean ok = service.ingestFile(file, institution + externalId);


### PR DESCRIPTION
## Summary
- load CSV mapping files during CsvReaderModule construction and expose readers
- inject Set<TransactionCsvReader> directly into IngestService
- update service module and tests for set-based readers

## Testing
- `make deps` (fails: No rule to make target 'deps')
- `./gradlew test`
- `make build-app` (fails: Failure: the server hosted at that remote is unavailable.)

------
https://chatgpt.com/codex/tasks/task_e_68bb1bd0da808325b036de0d858440c6