### PR TITLE
Ensure ingest-service jar has Main-Class manifest

### DIFF
--- a/apps/ingest-service/build.gradle
+++ b/apps/ingest-service/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'java'
     id 'nu.studer.jooq' version '9.0'
+    id 'com.github.johnrengelman.shadow' version '8.1.1'
 }
 
 group = 'org.artificers'
@@ -78,6 +79,21 @@ jooq {
 
 tasks.withType(Test) {
     useJUnitPlatform()
+}
+
+shadowJar {
+    archiveClassifier.set('')
+    manifest {
+        attributes 'Main-Class': 'org.artificers.ingest.IngestApp'
+    }
+}
+
+tasks.build {
+    dependsOn shadowJar
+}
+
+jar {
+    enabled = false
 }
 
 tasks.register('newAccount', JavaExec) {


### PR DESCRIPTION
## Summary
- package ingest-service using the Shadow plugin to produce a runnable fat jar
- set the manifest `Main-Class` to `IngestApp` and disable the plain jar

## Testing
- `cd apps/ingest-service && ./gradlew test`
- `make build-app` *(fails: Failure: the server hosted at that remote is unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68bb2f0b07f08325b00f7c128f49a0b7