### PR TITLE
refactor: extract ingestion services

### DIFF
--- a/apps/ingest-service/src/main/java/org/artificers/ingest/FileIngestionService.java
+++ b/apps/ingest-service/src/main/java/org/artificers/ingest/FileIngestionService.java
@@ -1,0 +1,39 @@
+package org.artificers.ingest;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+
+/** Handles scanning directories and moving ingested files. */
+public class FileIngestionService {
+    private static final Logger log = LoggerFactory.getLogger(FileIngestionService.class);
+    private final IngestService ingestService;
+
+    public FileIngestionService(IngestService ingestService) {
+        this.ingestService = ingestService;
+    }
+
+    public void scanAndIngest(Path input) throws IOException {
+        log.info("Scanning directory {}", input.toAbsolutePath());
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(input, "*.csv")) {
+            for (Path file : stream) {
+                log.info("Found file {}", file);
+                String shorthand = AccountResolver.extractShorthand(file);
+                if (shorthand == null) {
+                    log.warn("Skipping file {} with unrecognized name", file);
+                    continue;
+                }
+                boolean ok = ingestService.ingestFile(file, shorthand);
+                log.info("Ingestion {} for file {}", ok ? "succeeded" : "failed", file);
+                Path targetDir = input.resolveSibling(ok ? "processed" : "error");
+                Files.createDirectories(targetDir);
+                Files.move(file, targetDir.resolve(file.getFileName()), StandardCopyOption.REPLACE_EXISTING);
+            }
+        }
+    }
+}

--- a/apps/ingest-service/src/main/java/org/artificers/ingest/IngestApp.java
+++ b/apps/ingest-service/src/main/java/org/artificers/ingest/IngestApp.java
@@ -24,11 +24,14 @@ public final class IngestApp implements Callable<Integer> {
     Path input;
 
     private final IngestService service;
+    private final FileIngestionService fileService;
     private final DirectoryWatchService watchService;
     private final IngestConfig config;
 
-    public IngestApp(IngestService service, DirectoryWatchService watchService, IngestConfig config) {
+    public IngestApp(IngestService service, FileIngestionService fileService,
+                     DirectoryWatchService watchService, IngestConfig config) {
         this.service = service;
+        this.fileService = fileService;
         this.watchService = watchService;
         this.config = config;
     }
@@ -45,7 +48,7 @@ public final class IngestApp implements Callable<Integer> {
         }
         if ("scan".equals(mode)) {
             Path dir = input != null ? input : config.ingestDir();
-            service.scanAndIngest(dir);
+            fileService.scanAndIngest(dir);
             return 0;
         }
         try (DirectoryWatchService watch = watchService) {
@@ -72,8 +75,9 @@ public final class IngestApp implements Callable<Integer> {
                 .ingestConfig(cfg)
                 .build();
         IngestService service = component.ingestService();
+        FileIngestionService fileService = component.fileIngestionService();
         DirectoryWatchService watch = component.directoryWatchService();
-        int code = new CommandLine(new IngestApp(service, watch, cfg)).execute(args);
+        int code = new CommandLine(new IngestApp(service, fileService, watch, cfg)).execute(args);
         System.exit(code);
     }
 

--- a/apps/ingest-service/src/main/java/org/artificers/ingest/IngestComponent.java
+++ b/apps/ingest-service/src/main/java/org/artificers/ingest/IngestComponent.java
@@ -10,6 +10,7 @@ import org.artificers.ingest.cli.NewAccountCli;
 @Component(modules = {DataModule.class, CsvReaderModule.class, ServiceModule.class})
 public interface IngestComponent {
     IngestService ingestService();
+    FileIngestionService fileIngestionService();
     DirectoryWatchService directoryWatchService();
     NewAccountCli newAccountCli();
 

--- a/apps/ingest-service/src/main/java/org/artificers/ingest/MaterializedViewRefresher.java
+++ b/apps/ingest-service/src/main/java/org/artificers/ingest/MaterializedViewRefresher.java
@@ -1,0 +1,31 @@
+package org.artificers.ingest;
+
+import org.jooq.DSLContext;
+import org.jooq.impl.DSL;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Refreshes materialized views after ingestion. */
+public class MaterializedViewRefresher {
+    private static final Logger log = LoggerFactory.getLogger(MaterializedViewRefresher.class);
+    private final DSLContext dsl;
+
+    public MaterializedViewRefresher(DSLContext dsl) {
+        this.dsl = dsl;
+    }
+
+    public void refreshTransactionsView() {
+        try {
+            boolean exists = dsl.fetchExists(
+                    DSL.selectOne()
+                            .from("pg_matviews")
+                            .where(DSL.field("matviewname").eq("transactions_view"))
+            );
+            if (exists) {
+                dsl.execute("REFRESH MATERIALIZED VIEW transactions_view");
+            }
+        } catch (Exception e) {
+            log.debug("Skipping materialized view refresh: {}", e.getMessage());
+        }
+    }
+}

--- a/apps/ingest-service/src/main/java/org/artificers/ingest/ServiceModule.java
+++ b/apps/ingest-service/src/main/java/org/artificers/ingest/ServiceModule.java
@@ -25,8 +25,30 @@ public interface ServiceModule {
 
     @Provides
     @Singleton
-    static IngestService ingestService(DSLContext dsl, AccountResolver resolver, Set<TransactionCsvReader> readers) {
-        return new IngestService(dsl, resolver, readers);
+    static TransactionRepository transactionRepository() {
+        return new TransactionRepository();
+    }
+
+    @Provides
+    @Singleton
+    static MaterializedViewRefresher materializedViewRefresher(DSLContext dsl) {
+        return new MaterializedViewRefresher(dsl);
+    }
+
+    @Provides
+    @Singleton
+    static IngestService ingestService(DSLContext dsl,
+                                       AccountResolver resolver,
+                                       Set<TransactionCsvReader> readers,
+                                       TransactionRepository repo,
+                                       MaterializedViewRefresher refresher) {
+        return new IngestService(dsl, resolver, readers, repo, refresher);
+    }
+
+    @Provides
+    @Singleton
+    static FileIngestionService fileIngestionService(IngestService service) {
+        return new FileIngestionService(service);
     }
 
     @Provides

--- a/apps/ingest-service/src/main/java/org/artificers/ingest/TransactionRepository.java
+++ b/apps/ingest-service/src/main/java/org/artificers/ingest/TransactionRepository.java
@@ -1,0 +1,42 @@
+package org.artificers.ingest;
+
+import org.artificers.jooq.tables.Transactions;
+import org.jooq.DSLContext;
+import org.jooq.JSONB;
+import org.jooq.exception.DataAccessException;
+
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+/** Repository for transaction persistence. */
+public class TransactionRepository {
+    public void upsert(DSLContext ctx, TransactionRecord t, ResolvedAccount account) {
+        try {
+            ctx.insertInto(Transactions.TRANSACTIONS)
+                    .set(Transactions.TRANSACTIONS.ACCOUNT_ID, account.id())
+                    .set(Transactions.TRANSACTIONS.OCCURRED_AT, toOffsetDateTime(t.occurredAt()))
+                    .set(Transactions.TRANSACTIONS.POSTED_AT, toOffsetDateTime(t.postedAt()))
+                    .set(Transactions.TRANSACTIONS.AMOUNT_CENTS, t.amountCents())
+                    .set(Transactions.TRANSACTIONS.CURRENCY, t.currency())
+                    .set(Transactions.TRANSACTIONS.MERCHANT, t.merchant())
+                    .set(Transactions.TRANSACTIONS.CATEGORY, t.category())
+                    .set(Transactions.TRANSACTIONS.TXN_TYPE, t.type())
+                    .set(Transactions.TRANSACTIONS.MEMO, t.memo())
+                    .set(Transactions.TRANSACTIONS.HASH, t.hash())
+                    .set(Transactions.TRANSACTIONS.RAW_JSON, JSONB.valueOf(t.rawJson()))
+                    .onConflict(
+                            Transactions.TRANSACTIONS.ACCOUNT_ID,
+                            Transactions.TRANSACTIONS.HASH
+                    )
+                    .doNothing()
+                    .execute();
+        } catch (DataAccessException e) {
+            throw new TransactionIngestException(t, e);
+        }
+    }
+
+    private OffsetDateTime toOffsetDateTime(Instant i) {
+        return i == null ? null : OffsetDateTime.ofInstant(i, ZoneOffset.UTC);
+    }
+}

--- a/apps/ingest-service/src/test/java/org/artificers/ingest/FileIngestionServiceTest.java
+++ b/apps/ingest-service/src/test/java/org/artificers/ingest/FileIngestionServiceTest.java
@@ -20,7 +20,7 @@ import java.util.Set;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
-class IngestServiceTest {
+class FileIngestionServiceTest {
     @Test
     void routesByFilenameAndCreatesAccounts(@TempDir Path dir) throws Exception {
         MockDataProvider provider = ctx -> new MockResult[0];
@@ -39,8 +39,11 @@ class IngestServiceTest {
         copyResource("ch1234-example.csv", dir.resolve("ch1234-example.csv"));
         copyResource("co1828-example.csv", dir.resolve("co1828-example.csv"));
 
-        IngestService service = new IngestService(dsl, resolver, Set.of(chReader, coReader));
-        service.scanAndIngest(dir);
+        TransactionRepository repo = new TransactionRepository();
+        MaterializedViewRefresher refresher = new MaterializedViewRefresher(dsl);
+        IngestService service = new IngestService(dsl, resolver, Set.of(chReader, coReader), repo, refresher);
+        FileIngestionService fileService = new FileIngestionService(service);
+        fileService.scanAndIngest(dir);
 
         verify(chReader).read(eq(dir.resolve("ch1234-example.csv")), any(), eq("1234"));
         verify(coReader).read(eq(dir.resolve("co1828-example.csv")), any(), eq("1828"));

--- a/apps/ingest-service/src/test/java/org/artificers/ingest/IngestAppTest.java
+++ b/apps/ingest-service/src/test/java/org/artificers/ingest/IngestAppTest.java
@@ -13,11 +13,12 @@ class IngestAppTest {
     @Test
     void ingestsFileWhenFileOptionPresent() throws Exception {
         IngestService service = mock(IngestService.class);
+        FileIngestionService fileService = mock(FileIngestionService.class);
         when(service.ingestFile(any(), any())).thenReturn(true);
         DirectoryWatchService watch = mock(DirectoryWatchService.class);
         IngestConfig cfg = new IngestConfig(Path.of("storage/incoming"), Path.of("cfg"));
 
-        int code = new CommandLine(new IngestApp(service, watch, cfg)).execute("--file=/tmp/ch1234.csv");
+        int code = new CommandLine(new IngestApp(service, fileService, watch, cfg)).execute("--file=/tmp/ch1234.csv");
 
         verify(service).ingestFile(Path.of("/tmp/ch1234.csv"), "ch1234");
         assertThat(code).isZero();
@@ -26,24 +27,26 @@ class IngestAppTest {
     @Test
     void scansDirectoryWhenModeScanWithInput() throws Exception {
         IngestService service = mock(IngestService.class);
+        FileIngestionService fileService = mock(FileIngestionService.class);
         DirectoryWatchService watch = mock(DirectoryWatchService.class);
         IngestConfig cfg = new IngestConfig(Path.of("storage/incoming"), Path.of("cfg"));
 
-        int code = new CommandLine(new IngestApp(service, watch, cfg)).execute("--mode=scan", "--input=/tmp/in");
+        int code = new CommandLine(new IngestApp(service, fileService, watch, cfg)).execute("--mode=scan", "--input=/tmp/in");
 
-        verify(service).scanAndIngest(Path.of("/tmp/in"));
+        verify(fileService).scanAndIngest(Path.of("/tmp/in"));
         assertThat(code).isZero();
     }
 
     @Test
     void scansDefaultDirectoryWhenInputMissing() throws Exception {
         IngestService service = mock(IngestService.class);
+        FileIngestionService fileService = mock(FileIngestionService.class);
         DirectoryWatchService watch = mock(DirectoryWatchService.class);
         IngestConfig cfg = new IngestConfig(Path.of("storage/incoming"), Path.of("cfg"));
 
-        int code = new CommandLine(new IngestApp(service, watch, cfg)).execute("--mode=scan");
+        int code = new CommandLine(new IngestApp(service, fileService, watch, cfg)).execute("--mode=scan");
 
-        verify(service).scanAndIngest(Path.of("storage/incoming"));
+        verify(fileService).scanAndIngest(Path.of("storage/incoming"));
         assertThat(code).isZero();
     }
 }

--- a/apps/ingest-service/src/test/java/org/artificers/ingest/IngestServiceTransactionTest.java
+++ b/apps/ingest-service/src/test/java/org/artificers/ingest/IngestServiceTransactionTest.java
@@ -36,7 +36,9 @@ class IngestServiceTransactionTest {
         when(reader.read(any(), any(), eq("1234"))).thenReturn(List.of(t1, t2));
 
         Files.writeString(dir.resolve(institution + "1234.csv"), "id,amount\n1,10");
-        IngestService service = new IngestService(dsl, resolver, Set.of(reader));
+        TransactionRepository repo = new TransactionRepository();
+        MaterializedViewRefresher refresher = new MaterializedViewRefresher(dsl);
+        IngestService service = new IngestService(dsl, resolver, Set.of(reader), repo, refresher);
         boolean ok = service.ingestFile(dir.resolve(institution + "1234.csv"), institution + "1234");
 
         assertThat(ok).isTrue();

--- a/apps/ingest-service/src/test/java/org/artificers/ingest/IngestServiceViewTest.java
+++ b/apps/ingest-service/src/test/java/org/artificers/ingest/IngestServiceViewTest.java
@@ -56,7 +56,9 @@ class IngestServiceViewTest {
 
         ConfigurableCsvReader reader = reader(institution);
         AccountResolver resolver = new AccountResolver(dsl);
-        IngestService service = new IngestService(dsl, resolver, Set.of(reader));
+        TransactionRepository repo = new TransactionRepository();
+        MaterializedViewRefresher refresher = new MaterializedViewRefresher(dsl);
+        IngestService service = new IngestService(dsl, resolver, Set.of(reader), repo, refresher);
 
         Path file = copyResource("/examples/" + fileName, dir);
         boolean ok = service.ingestFile(file, institution + externalId);

--- a/apps/ingest-service/src/test/java/org/artificers/ingest/TransactionRepositoryRawJsonTest.java
+++ b/apps/ingest-service/src/test/java/org/artificers/ingest/TransactionRepositoryRawJsonTest.java
@@ -9,14 +9,11 @@ import org.jooq.tools.jdbc.MockExecuteContext;
 import org.jooq.tools.jdbc.MockResult;
 import org.junit.jupiter.api.Test;
 
-import java.lang.reflect.Method;
-import java.util.List;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class IngestServiceRawJsonTest {
+class TransactionRepositoryRawJsonTest {
     @Test
     void upsertCastsRawJsonParameterToJsonb() throws Exception {
         AtomicReference<String> sql = new AtomicReference<>();
@@ -28,13 +25,11 @@ class IngestServiceRawJsonTest {
             }
         };
         DSLContext dsl = DSL.using(new MockConnection(provider), SQLDialect.POSTGRES);
-        IngestService service = new IngestService(dsl, null, Set.of());
+        TransactionRepository repo = new TransactionRepository();
         TransactionRecord tx = new GenericTransaction("a", null, null, 100, "USD", "m", "c", null, null, "h", "{}");
         ResolvedAccount account = new ResolvedAccount(1, "co", "a");
 
-        Method m = IngestService.class.getDeclaredMethod("upsert", DSLContext.class, TransactionRecord.class, ResolvedAccount.class);
-        m.setAccessible(true);
-        m.invoke(service, dsl, tx, account);
+        repo.upsert(dsl, tx, account);
 
         assertThat(sql.get()).contains("cast(? as jsonb)");
     }


### PR DESCRIPTION
## Summary
- split file scanning/moving into new `FileIngestionService`
- delegate transaction persistence to `TransactionRepository` and materialized view refresh to `MaterializedViewRefresher`
- wire `IngestApp` through the new services

## Testing
- `cd apps/ingest-service && ./gradlew test`
- `make build-app` *(fails: Failure: the server hosted at that remote is unavailable.)*

------
https://chatgpt.com/codex/tasks/task_e_68bb468b0b788325a50590c9cafc64e0