### PR TITLE
refactor: inject watch service dependencies

### DIFF
--- a/apps/ingest-service/src/main/java/org/artificers/ingest/DirectoryWatchService.java
+++ b/apps/ingest-service/src/main/java/org/artificers/ingest/DirectoryWatchService.java
@@ -6,45 +6,41 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.nio.file.*;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import java.util.function.Function;
 
 public class DirectoryWatchService implements AutoCloseable {
     private static final Logger log = LoggerFactory.getLogger(DirectoryWatchService.class);
 
-    private final IngestService ingestService;
     private final Path directory;
     private final ExecutorService executor;
-    private WatchService watchService;
-    private static final Pattern FILE_PATTERN = Pattern.compile("^([a-zA-Z]+\\d{4}).*\\.csv$");
+    private final WatchService watchService;
+    private final FileIngestionService fileService;
+    private final Function<Path, String> shorthandParser;
 
-    public DirectoryWatchService(IngestService ingestService, Path dir) {
-        this.ingestService = ingestService;
+    public DirectoryWatchService(FileIngestionService fileService,
+                                 Path dir,
+                                 ExecutorService executor,
+                                 WatchService watchService,
+                                 Function<Path, String> shorthandParser) {
+        this.fileService = fileService;
         this.directory = dir.toAbsolutePath();
-        this.executor = Executors.newSingleThreadExecutor(r -> {
-            Thread t = new Thread(r);
-            t.setDaemon(true);
-            t.setName("directory-watch");
-            return t;
-        });
+        this.executor = executor;
+        this.watchService = watchService;
+        this.shorthandParser = shorthandParser;
     }
 
     public void start() throws IOException {
         Files.createDirectories(directory);
         log.info("Watching directory {} for new files", directory);
-        watchService = FileSystems.getDefault().newWatchService();
         directory.register(watchService, StandardWatchEventKinds.ENTRY_CREATE);
-        scanDirectory();
+        fileService.scanAndIngest(directory);
         executor.submit(this::processEvents);
     }
 
     public void stop() throws IOException {
         executor.shutdownNow();
-        if (watchService != null) {
-            watchService.close();
-        }
+        watchService.close();
     }
 
     @Override
@@ -61,16 +57,24 @@ public class DirectoryWatchService implements AutoCloseable {
                     for (WatchEvent<?> event : key.pollEvents()) {
                         if (event.kind() == StandardWatchEventKinds.ENTRY_CREATE) {
                             Path filename = (Path) event.context();
-                            Matcher m = FILE_PATTERN.matcher(filename.toString());
-                            if (m.matches()) {
-                                String shorthand = m.group(1).toLowerCase();
-                                handleFile(filename, shorthand);
+                            Path file = directory.resolve(filename);
+                            String shorthand = shorthandParser.apply(file);
+                            if (shorthand != null) {
+                                try {
+                                    fileService.ingestFile(file, shorthand);
+                                } catch (IOException e) {
+                                    log.error("Failed to ingest file {}", file, e);
+                                }
                             }
                         }
                     }
                     key.reset();
                 }
-                scanDirectory();
+                try {
+                    fileService.scanAndIngest(directory);
+                } catch (IOException e) {
+                    log.error("Failed to scan directory {}", directory, e);
+                }
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
             } catch (Exception e) {
@@ -78,32 +82,4 @@ public class DirectoryWatchService implements AutoCloseable {
             }
         }
     }
-
-    private void scanDirectory() {
-        try (DirectoryStream<Path> stream = Files.newDirectoryStream(directory, "*.csv")) {
-            for (Path file : stream) {
-                Matcher m = FILE_PATTERN.matcher(file.getFileName().toString());
-                if (m.matches()) {
-                    handleFile(file.getFileName(), m.group(1).toLowerCase());
-                }
-            }
-        } catch (IOException e) {
-            log.error("Failed to scan directory {}", directory, e);
-        }
-    }
-
-    private void handleFile(Path filename, String shorthand) {
-        Path file = directory.resolve(filename);
-        log.info("Processing file {} with shorthand {}", file, shorthand);
-        boolean ok = ingestService.ingestFile(file, shorthand);
-        log.info("Finished processing file {}: {}", file, ok ? "success" : "failure");
-        Path target = directory.resolve(ok ? "processed" : "error");
-        try {
-            Files.createDirectories(target);
-            Files.move(file, target.resolve(filename), StandardCopyOption.REPLACE_EXISTING);
-        } catch (IOException e) {
-            log.error("Failed to move file {} to {}", file, target, e);
-        }
-    }
 }
-

--- a/apps/ingest-service/src/main/java/org/artificers/ingest/FileIngestionService.java
+++ b/apps/ingest-service/src/main/java/org/artificers/ingest/FileIngestionService.java
@@ -8,14 +8,18 @@ import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.util.function.Function;
 
 /** Handles scanning directories and moving ingested files. */
 public class FileIngestionService {
     private static final Logger log = LoggerFactory.getLogger(FileIngestionService.class);
     private final IngestService ingestService;
+    private final Function<Path, String> shorthandParser;
 
-    public FileIngestionService(IngestService ingestService) {
+    public FileIngestionService(IngestService ingestService,
+                                Function<Path, String> shorthandParser) {
         this.ingestService = ingestService;
+        this.shorthandParser = shorthandParser;
     }
 
     public void scanAndIngest(Path input) throws IOException {
@@ -23,17 +27,21 @@ public class FileIngestionService {
         try (DirectoryStream<Path> stream = Files.newDirectoryStream(input, "*.csv")) {
             for (Path file : stream) {
                 log.info("Found file {}", file);
-                String shorthand = AccountResolver.extractShorthand(file);
+                String shorthand = shorthandParser.apply(file);
                 if (shorthand == null) {
                     log.warn("Skipping file {} with unrecognized name", file);
                     continue;
                 }
-                boolean ok = ingestService.ingestFile(file, shorthand);
-                log.info("Ingestion {} for file {}", ok ? "succeeded" : "failed", file);
-                Path targetDir = input.resolveSibling(ok ? "processed" : "error");
-                Files.createDirectories(targetDir);
-                Files.move(file, targetDir.resolve(file.getFileName()), StandardCopyOption.REPLACE_EXISTING);
+                ingestFile(file, shorthand);
             }
         }
+    }
+
+    public void ingestFile(Path file, String shorthand) throws IOException {
+        boolean ok = ingestService.ingestFile(file, shorthand);
+        log.info("Ingestion {} for file {}", ok ? "succeeded" : "failed", file);
+        Path targetDir = file.getParent().resolve(ok ? "processed" : "error");
+        Files.createDirectories(targetDir);
+        Files.move(file, targetDir.resolve(file.getFileName()), StandardCopyOption.REPLACE_EXISTING);
     }
 }

--- a/apps/ingest-service/src/test/java/org/artificers/ingest/FileIngestionServiceTest.java
+++ b/apps/ingest-service/src/test/java/org/artificers/ingest/FileIngestionServiceTest.java
@@ -42,7 +42,7 @@ class FileIngestionServiceTest {
         TransactionRepository repo = new TransactionRepository();
         MaterializedViewRefresher refresher = new MaterializedViewRefresher(dsl);
         IngestService service = new IngestService(dsl, resolver, Set.of(chReader, coReader), repo, refresher);
-        FileIngestionService fileService = new FileIngestionService(service);
+        FileIngestionService fileService = new FileIngestionService(service, AccountResolver::extractShorthand);
         fileService.scanAndIngest(dir);
 
         verify(chReader).read(eq(dir.resolve("ch1234-example.csv")), any(), eq("1234"));


### PR DESCRIPTION
## Summary
- inject ExecutorService, WatchService, and shorthand parser into DirectoryWatchService and delegate processing to FileIngestionService
- allow FileIngestionService to parse shorthands and ingest individual files
- provide new dependencies via Dagger and update tests accordingly

## Testing
- `cd apps/ingest-service && ./gradlew test`
- `make build-app` *(fails: server hosted at remote unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68bb48db438483258fd4f9e500be4b7b