### PR TITLE
Refactor Account to immutable record

### DIFF
--- a/apps/ingest-service/src/main/java/org/artificers/ingest/Account.java
+++ b/apps/ingest-service/src/main/java/org/artificers/ingest/Account.java
@@ -2,11 +2,14 @@ package org.artificers.ingest;
 
 import java.time.Instant;
 
-public class Account {
-    public long id;
-    public String institution;
-    public String externalId;
-    public String displayName;
-    public Instant createdAt;
-    public Instant updatedAt;
-}
+/**
+ * Immutable account record.
+ */
+public record Account(
+        long id,
+        String institution,
+        String externalId,
+        String displayName,
+        Instant createdAt,
+        Instant updatedAt
+) {}

--- a/apps/ingest-service/src/test/java/org/artificers/ingest/AccountTest.java
+++ b/apps/ingest-service/src/test/java/org/artificers/ingest/AccountTest.java
@@ -1,0 +1,30 @@
+package org.artificers.ingest;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Modifier;
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class AccountTest {
+    @Test
+    void isImmutableRecord() {
+        Instant now = Instant.now();
+        Account account = new Account(1L, "inst", "ext", "name", now, now);
+
+        assertEquals(1L, account.id());
+        assertEquals("inst", account.institution());
+        assertEquals("ext", account.externalId());
+        assertEquals("name", account.displayName());
+        assertEquals(now, account.createdAt());
+        assertEquals(now, account.updatedAt());
+
+        assertTrue(Account.class.isRecord(), "Account should be a record");
+        assertTrue(Modifier.isFinal(Account.class.getModifiers()), "Account should be final");
+        for (var field : Account.class.getDeclaredFields()) {
+            assertTrue(Modifier.isPrivate(field.getModifiers()), "Field " + field.getName() + " should be private");
+            assertTrue(Modifier.isFinal(field.getModifiers()), "Field " + field.getName() + " should be final");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- refactor Account into a Java record for immutability
- add unit test verifying Account's record fields remain private and final

## Testing
- `make deps` *(fails: No rule to make target 'deps')*
- `cd apps/ingest-service && ./gradlew test`
- `make build-app` *(fails: the server hosted at that remote is unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68bb4cc8b5548325a5ccb53f84dae3cf