### PR TITLE
Inject ObjectMapper into CSV reader and refactor helpers

### DIFF
--- a/apps/ingest-service/src/main/java/org/artificers/ingest/BaseCsvReader.java
+++ b/apps/ingest-service/src/main/java/org/artificers/ingest/BaseCsvReader.java
@@ -53,4 +53,18 @@ abstract class BaseCsvReader {
                 .replaceAll("_+", "_")
                 .replaceAll("^_|_$", "");
     }
+
+    protected Instant parseTimestamp(String v, String format) {
+        if (v == null || v.isBlank()) return null;
+        if (format != null && !format.isBlank()) {
+            DateTimeFormatter fmt = DateTimeFormatter.ofPattern(format).withZone(ZoneOffset.UTC);
+            try {
+                return Instant.from(fmt.parse(v));
+            } catch (DateTimeParseException e) {
+                LocalDate d = LocalDate.parse(v, fmt);
+                return d.atStartOfDay(ZoneOffset.UTC).toInstant();
+            }
+        }
+        return parseDate(v);
+    }
 }

--- a/apps/ingest-service/src/main/java/org/artificers/ingest/CsvReaderModule.java
+++ b/apps/ingest-service/src/main/java/org/artificers/ingest/CsvReaderModule.java
@@ -22,7 +22,7 @@ public final class CsvReaderModule {
     CsvReaderModule(ObjectMapper mapper) {
         try {
             this.readers = new MappingFileLocator(mapper).locate().stream()
-                    .map(ConfigurableCsvReader::new)
+                    .map(m -> new ConfigurableCsvReader(mapper, m))
                     .collect(Collectors.toUnmodifiableSet());
         } catch (IOException e) {
             throw new UncheckedIOException("Failed to load CSV mappings", e);

--- a/apps/ingest-service/src/main/java/org/artificers/ingest/HashGenerator.java
+++ b/apps/ingest-service/src/main/java/org/artificers/ingest/HashGenerator.java
@@ -1,0 +1,13 @@
+package org.artificers.ingest;
+
+import java.time.Instant;
+import org.apache.commons.codec.digest.DigestUtils;
+
+final class HashGenerator {
+    private HashGenerator() {}
+
+    static String sha256(String accountId, long amountCents, Instant occurredAt, String merchant) {
+        String occurred = occurredAt == null ? "" : occurredAt.toString();
+        return DigestUtils.sha256Hex(accountId + amountCents + occurred + merchant);
+    }
+}

--- a/apps/ingest-service/src/test/java/org/artificers/ingest/AccountCreationIntegrationTest.java
+++ b/apps/ingest-service/src/test/java/org/artificers/ingest/AccountCreationIntegrationTest.java
@@ -42,7 +42,7 @@ public class AccountCreationIntegrationTest {
         try (InputStream in = getClass().getResourceAsStream("/mappings/" + institution + ".json")) {
             ConfigurableCsvReader.Mapping mapping =
                     new com.fasterxml.jackson.databind.ObjectMapper().readValue(in, ConfigurableCsvReader.Mapping.class);
-            return new ConfigurableCsvReader(mapping);
+            return new ConfigurableCsvReader(new com.fasterxml.jackson.databind.ObjectMapper(), mapping);
         }
     }
 

--- a/apps/ingest-service/src/test/java/org/artificers/ingest/ConfigurableCsvReaderTest.java
+++ b/apps/ingest-service/src/test/java/org/artificers/ingest/ConfigurableCsvReaderTest.java
@@ -11,10 +11,10 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.*;
 
 class ConfigurableCsvReaderTest {
-    private ConfigurableCsvReader reader(String name) throws Exception {
+    private ConfigurableCsvReader reader(String name, ObjectMapper mapper) throws Exception {
         try (InputStream in = getClass().getResourceAsStream("/mappings/" + name + ".json")) {
             ConfigurableCsvReader.Mapping mapping = new ObjectMapper().readValue(in, ConfigurableCsvReader.Mapping.class);
-            return new ConfigurableCsvReader(mapping);
+            return new ConfigurableCsvReader(mapper, mapping);
         }
     }
 
@@ -23,7 +23,7 @@ class ConfigurableCsvReaderTest {
         String csv = "Transaction Date,Post Date,Description,Category,Type,Amount,Memo\n" +
                 "04/30/2025,04/30/2025,Payment Thank You-Mobile,,Payment,18.62,\n" +
                 "04/27/2025,04/29/2025,JetBrains Americas INC,Shopping,Sale,-18.62,\n";
-        ConfigurableCsvReader reader = reader("ch");
+        ConfigurableCsvReader reader = reader("ch", new ObjectMapper());
         List<TransactionRecord> txs = reader.read(null, new StringReader(csv), "1234");
         assertEquals(2, txs.size());
         TransactionRecord t0 = txs.get(0);
@@ -44,7 +44,7 @@ class ConfigurableCsvReaderTest {
         String csv = "Transaction Date,Posted Date,Card No.,Description,Category,Debit,Credit\n" +
                 "2025-04-30,2025-04-30,1828,CAPITAL ONE MOBILE PYMT,Payment/Credit,,600.00\n" +
                 "2025-04-28,2025-04-30,1828,TST*ROYAL BAKEHOUSE,Dining,14.12,\n";
-        ConfigurableCsvReader reader = reader("co");
+        ConfigurableCsvReader reader = reader("co", new ObjectMapper());
         List<TransactionRecord> txs = reader.read(null, new StringReader(csv), "1828");
         assertEquals(2, txs.size());
         TransactionRecord t0 = txs.get(0);
@@ -70,7 +70,7 @@ class ConfigurableCsvReaderTest {
                 "\"credit\":{\"target\":\"amount_cents\",\"type\":\"int\"}" +
                 "}}";
         ConfigurableCsvReader.Mapping m = new ObjectMapper().readValue(mapping, ConfigurableCsvReader.Mapping.class);
-        ConfigurableCsvReader reader = new ConfigurableCsvReader(m);
+        ConfigurableCsvReader reader = new ConfigurableCsvReader(new ObjectMapper(), m);
         String csv = "date,debit,credit\n" +
                 "2025-04-30,100,0\n" +
                 "2025-04-29,0,200\n";
@@ -78,5 +78,23 @@ class ConfigurableCsvReaderTest {
         assertEquals(2, txs.size());
         assertEquals(-100, txs.get(0).amountCents());
         assertEquals(200, txs.get(1).amountCents());
+    }
+
+    @Test
+    void usesInjectedMapper() throws Exception {
+        class CountingMapper extends ObjectMapper {
+            int calls = 0;
+            @Override
+            public com.fasterxml.jackson.databind.JsonNode valueToTree(Object fromValue) {
+                calls++;
+                return super.valueToTree(fromValue);
+            }
+        }
+        CountingMapper mapper = new CountingMapper();
+        ConfigurableCsvReader reader = reader("ch", mapper);
+        String csv = "Transaction Date,Post Date,Description,Category,Type,Amount,Memo\n" +
+                "04/30/2025,04/30/2025,Payment Thank You-Mobile,,Payment,18.62,\n";
+        reader.read(null, new StringReader(csv), "1234");
+        assertTrue(mapper.calls > 0);
     }
 }

--- a/apps/ingest-service/src/test/java/org/artificers/ingest/IngestServiceViewTest.java
+++ b/apps/ingest-service/src/test/java/org/artificers/ingest/IngestServiceViewTest.java
@@ -21,7 +21,7 @@ class IngestServiceViewTest {
         try (InputStream in = getClass().getResourceAsStream("/mappings/" + institution + ".json")) {
             ConfigurableCsvReader.Mapping mapping =
                     new ObjectMapper().readValue(in, ConfigurableCsvReader.Mapping.class);
-            return new ConfigurableCsvReader(mapping);
+            return new ConfigurableCsvReader(new ObjectMapper(), mapping);
         }
     }
 


### PR DESCRIPTION
## Summary
- inject a shared `ObjectMapper` into `ConfigurableCsvReader`
- extract hash generation and timestamp parsing into helper utilities
- supply mapper in `CsvReaderModule` and update tests for injected mapper

## Testing
- `make deps` *(fails: No rule to make target 'deps')*
- `cd apps/ingest-service && gradle wrapper`
- `cd apps/ingest-service && ./gradlew test`
- `make build-app` *(fails: Failure: the server hosted at that remote is unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68bb4f898cb483258d37f91055a3aad0