### PR TITLE
Use enum for CSV field targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,13 +72,13 @@ normalized header to a target field and type:
 institution: xx
 fields:
   transaction_date:
-    target: occurred_at
+    target: OCCURRED_AT
     type: timestamp
   amount:
-    target: amount_cents
+    target: AMOUNT_CENTS
     type: currency
   description:
-    target: merchant
+    target: MERCHANT
     type: string
 ```
 

--- a/apps/ingest-service/src/main/java/org/artificers/ingest/ConfigurableCsvReader.java
+++ b/apps/ingest-service/src/main/java/org/artificers/ingest/ConfigurableCsvReader.java
@@ -53,11 +53,10 @@ public class ConfigurableCsvReader extends BaseCsvReader implements TransactionC
             String v = row[i];
             FieldSpec spec = fields.get(h);
             if (spec != null) {
-                String target = spec.target();
-                switch (target) {
-                    case "occurred_at" -> occurredAt = parseTimestamp(v, spec.format());
-                    case "posted_at" -> postedAt = parseTimestamp(v, spec.format());
-                    case "amount_cents" -> {
+                switch (spec.target()) {
+                    case OCCURRED_AT -> occurredAt = parseTimestamp(v, spec.format());
+                    case POSTED_AT -> postedAt = parseTimestamp(v, spec.format());
+                    case AMOUNT_CENTS -> {
                         if ("currency".equals(spec.type())) {
                             long cents = parseAmount(v);
                             if (h.contains("debit")) {
@@ -74,14 +73,12 @@ public class ConfigurableCsvReader extends BaseCsvReader implements TransactionC
                             }
                         }
                     }
-                    case "currency" -> currency = v;
-                    case "merchant" -> merchant = v;
-                    case "category" -> category = v;
-                    case "type" -> type = v;
-                    case "memo" -> memo = v;
-                    default -> {
-                        raw.put(h, v);
-                    }
+                    case CURRENCY -> currency = v;
+                    case MERCHANT -> merchant = v;
+                    case CATEGORY -> category = v;
+                    case TYPE -> type = v;
+                    case MEMO -> memo = v;
+                    case RAW -> raw.put(h, v);
                 }
             } else {
                 raw.put(h, v);
@@ -98,5 +95,5 @@ public class ConfigurableCsvReader extends BaseCsvReader implements TransactionC
 
     public record Mapping(String institution, Map<String, FieldSpec> fields) {}
 
-    public record FieldSpec(String target, String type, String format) {}
+    public record FieldSpec(FieldTarget target, String type, String format) {}
 }

--- a/apps/ingest-service/src/main/java/org/artificers/ingest/FieldTarget.java
+++ b/apps/ingest-service/src/main/java/org/artificers/ingest/FieldTarget.java
@@ -1,0 +1,13 @@
+package org.artificers.ingest;
+
+public enum FieldTarget {
+    OCCURRED_AT,
+    POSTED_AT,
+    AMOUNT_CENTS,
+    CURRENCY,
+    MERCHANT,
+    CATEGORY,
+    TYPE,
+    MEMO,
+    RAW
+}

--- a/apps/ingest-service/src/main/resources/mappings/ch.json
+++ b/apps/ingest-service/src/main/resources/mappings/ch.json
@@ -1,12 +1,12 @@
 {
   "institution": "ch",
   "fields": {
-    "transaction_date": {"target": "occurred_at", "type": "timestamp"},
-    "post_date": {"target": "posted_at", "type": "timestamp"},
-    "description": {"target": "merchant", "type": "string"},
-    "category": {"target": "category", "type": "string"},
-    "type": {"target": "type", "type": "string"},
-    "amount": {"target": "amount_cents", "type": "currency"},
-    "memo": {"target": "memo", "type": "string"}
+    "transaction_date": {"target": "OCCURRED_AT", "type": "timestamp"},
+    "post_date": {"target": "POSTED_AT", "type": "timestamp"},
+    "description": {"target": "MERCHANT", "type": "string"},
+    "category": {"target": "CATEGORY", "type": "string"},
+    "type": {"target": "TYPE", "type": "string"},
+    "amount": {"target": "AMOUNT_CENTS", "type": "currency"},
+    "memo": {"target": "MEMO", "type": "string"}
   }
 }

--- a/apps/ingest-service/src/main/resources/mappings/co.json
+++ b/apps/ingest-service/src/main/resources/mappings/co.json
@@ -1,11 +1,11 @@
 {
   "institution": "co",
   "fields": {
-    "transaction_date": {"target": "occurred_at", "type": "timestamp"},
-    "posted_date": {"target": "posted_at", "type": "timestamp"},
-    "description": {"target": "merchant", "type": "string"},
-    "category": {"target": "category", "type": "string"},
-    "debit": {"target": "amount_cents", "type": "currency"},
-    "credit": {"target": "amount_cents", "type": "currency"}
+    "transaction_date": {"target": "OCCURRED_AT", "type": "timestamp"},
+    "posted_date": {"target": "POSTED_AT", "type": "timestamp"},
+    "description": {"target": "MERCHANT", "type": "string"},
+    "category": {"target": "CATEGORY", "type": "string"},
+    "debit": {"target": "AMOUNT_CENTS", "type": "currency"},
+    "credit": {"target": "AMOUNT_CENTS", "type": "currency"}
   }
 }

--- a/apps/ingest-service/src/main/resources/mappings/example.yaml
+++ b/apps/ingest-service/src/main/resources/mappings/example.yaml
@@ -1,11 +1,11 @@
 institution: xx
 fields:
   date:
-    target: occurred_at
+    target: OCCURRED_AT
     type: timestamp
   amount:
-    target: amount_cents
+    target: AMOUNT_CENTS
     type: currency
   description:
-    target: merchant
+    target: MERCHANT
     type: string

--- a/apps/ingest-service/src/test/java/org/artificers/ingest/ConfigurableCsvReaderTest.java
+++ b/apps/ingest-service/src/test/java/org/artificers/ingest/ConfigurableCsvReaderTest.java
@@ -65,9 +65,9 @@ class ConfigurableCsvReaderTest {
         String mapping = "{" +
                 "\"institution\":\"xx\"," +
                 "\"fields\":{" +
-                "\"date\":{\"target\":\"occurred_at\",\"type\":\"timestamp\"}," +
-                "\"debit\":{\"target\":\"amount_cents\",\"type\":\"int\"}," +
-                "\"credit\":{\"target\":\"amount_cents\",\"type\":\"int\"}" +
+                "\"date\":{\"target\":\"OCCURRED_AT\",\"type\":\"timestamp\"}," +
+                "\"debit\":{\"target\":\"AMOUNT_CENTS\",\"type\":\"int\"}," +
+                "\"credit\":{\"target\":\"AMOUNT_CENTS\",\"type\":\"int\"}" +
                 "}}";
         ConfigurableCsvReader.Mapping m = new ObjectMapper().readValue(mapping, ConfigurableCsvReader.Mapping.class);
         ConfigurableCsvReader reader = new ConfigurableCsvReader(new ObjectMapper(), m);


### PR DESCRIPTION
## Summary
- replace string field references with new `FieldTarget` enum
- switch CSV mapping logic to enum-based branching
- update mapping definitions, docs, and tests for enum targets

## Testing
- `make deps` *(fails: No rule to make target 'deps')*
- `cd apps/ingest-service && ./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68bb520e4d548325a377f9d84b271555