### PR TITLE
Refactor NewAccountCli for injection and add launcher

### DIFF
--- a/apps/ingest-service/build.gradle
+++ b/apps/ingest-service/build.gradle
@@ -98,5 +98,5 @@ jar {
 
 tasks.register('newAccount', JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
-    mainClass = 'org.artificers.ingest.cli.NewAccountCli'
+    mainClass = 'org.artificers.ingest.cli.NewAccountCliLauncher'
 }

--- a/apps/ingest-service/src/main/java/org/artificers/ingest/cli/NewAccountCliLauncher.java
+++ b/apps/ingest-service/src/main/java/org/artificers/ingest/cli/NewAccountCliLauncher.java
@@ -1,0 +1,41 @@
+package org.artificers.ingest.cli;
+
+import com.zaxxer.hikari.HikariDataSource;
+import org.jooq.DSLContext;
+import org.jooq.SQLDialect;
+import org.jooq.impl.DSL;
+import picocli.CommandLine;
+
+import java.nio.file.Path;
+
+/** Launcher for {@link NewAccountCli} that wires dependencies from environment variables. */
+public final class NewAccountCliLauncher {
+    private NewAccountCliLauncher() {}
+
+    public static void main(String[] args) throws Exception {
+        String url = System.getenv("DB_URL");
+        String user = System.getenv("DB_USER");
+        String password = System.getenv("DB_PASSWORD");
+        Path configDir = Path.of(System.getenv().getOrDefault(
+                "INGEST_CONFIG_DIR", System.getProperty("user.home") + "/.config/ingest"));
+
+        HikariDataSource ds = new HikariDataSource();
+        ds.setJdbcUrl(normalizeUrl(url));
+        ds.setUsername(user);
+        ds.setPassword(password);
+        DSLContext dsl = DSL.using(ds, SQLDialect.POSTGRES);
+        try {
+            int code = new CommandLine(new NewAccountCli(dsl, configDir)).execute(args);
+            System.exit(code);
+        } finally {
+            ds.close();
+        }
+    }
+
+    private static String normalizeUrl(String url) {
+        if (url == null) return null;
+        if (url.startsWith("jdbc:")) return url;
+        String normalized = url.replaceFirst("^postgres://", "postgresql://");
+        return "jdbc:" + normalized;
+    }
+}

--- a/apps/ingest-service/src/test/java/org/artificers/ingest/cli/NewAccountCliTest.java
+++ b/apps/ingest-service/src/test/java/org/artificers/ingest/cli/NewAccountCliTest.java
@@ -10,6 +10,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import org.jooq.DSLContext;
 import org.jooq.impl.DSL;
+import org.artificers.ingest.DbConfig;
+import org.artificers.ingest.DaggerIngestComponent;
+import org.artificers.ingest.IngestComponent;
+import org.artificers.ingest.IngestConfig;
 
 class NewAccountCliTest {
     @Test
@@ -41,5 +45,17 @@ class NewAccountCliTest {
         long id2 = NewAccountCli.insertAccount(dsl, "ch", "1234", "ignored");
         assertThat(id1).isEqualTo(id2);
         assertThat(dsl.fetchCount(DSL.table("accounts"))).isEqualTo(1);
+    }
+
+    @Test
+    void daggerConstructsCli() throws IOException {
+        Path configDir = Files.createTempDirectory("ingest-test");
+        DbConfig db = new DbConfig("jdbc:h2:mem:test;MODE=PostgreSQL;DATABASE_TO_UPPER=false", "sa", "");
+        IngestConfig cfg = new IngestConfig(Path.of("storage/incoming"), configDir);
+        IngestComponent component = DaggerIngestComponent.builder()
+                .dbConfig(db)
+                .ingestConfig(cfg)
+                .build();
+        assertThat(component.newAccountCli()).isNotNull();
     }
 }


### PR DESCRIPTION
## Summary
- Require `DSLContext` and config directory via `NewAccountCli` constructor
- Add `NewAccountCliLauncher` to wire dependencies from environment for production use
- Expose CLI through Dagger and update tests

## Testing
- `./gradlew test` *(fails: unable to access gradle-wrapper.jar)*
- `gradle test`
- `make build-app` *(fails: Failure: the server hosted at that remote is unavailable.)*


------
https://chatgpt.com/codex/tasks/task_e_68bb53871fe483259a7d00fab88e53ad