### PR TITLE
Introduce AccountShorthandParser

### DIFF
--- a/apps/ingest-service/src/main/java/org/artificers/ingest/AccountShorthandParser.java
+++ b/apps/ingest-service/src/main/java/org/artificers/ingest/AccountShorthandParser.java
@@ -1,0 +1,29 @@
+package org.artificers.ingest;
+
+import java.nio.file.Path;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/** Parses account shorthand strings and filenames. */
+public class AccountShorthandParser {
+    private static final Pattern SHORTHAND = Pattern.compile("^([A-Za-z]+)(\\d{4})$");
+    private static final Pattern FILE_PATTERN = Pattern.compile("^([A-Za-z]+\\d{4}).*\\.csv$");
+
+    /** Extracts the account shorthand from a CSV filename. */
+    public String extract(Path path) {
+        Matcher m = FILE_PATTERN.matcher(path.getFileName().toString());
+        return m.matches() ? m.group(1).toLowerCase() : null;
+    }
+
+    /** Parses a shorthand like {@code ch1234} into its components. */
+    public ParsedShorthand parse(String shorthand) {
+        if (shorthand == null) throw new IllegalArgumentException("Missing account shorthand");
+        Matcher m = SHORTHAND.matcher(shorthand.toLowerCase());
+        if (!m.matches()) throw new IllegalArgumentException("Invalid account shorthand");
+        return new ParsedShorthand(m.group(1), m.group(2));
+    }
+
+    /** Components of an account shorthand. */
+    public record ParsedShorthand(String institution, String externalId) {}
+}
+

--- a/apps/ingest-service/src/main/java/org/artificers/ingest/DirectoryWatchService.java
+++ b/apps/ingest-service/src/main/java/org/artificers/ingest/DirectoryWatchService.java
@@ -7,7 +7,6 @@ import java.io.IOException;
 import java.nio.file.*;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
 
 public class DirectoryWatchService implements AutoCloseable {
     private static final Logger log = LoggerFactory.getLogger(DirectoryWatchService.class);
@@ -16,13 +15,13 @@ public class DirectoryWatchService implements AutoCloseable {
     private final ExecutorService executor;
     private final WatchService watchService;
     private final FileIngestionService fileService;
-    private final Function<Path, String> shorthandParser;
+    private final AccountShorthandParser shorthandParser;
 
     public DirectoryWatchService(FileIngestionService fileService,
                                  Path dir,
                                  ExecutorService executor,
                                  WatchService watchService,
-                                 Function<Path, String> shorthandParser) {
+                                 AccountShorthandParser shorthandParser) {
         this.fileService = fileService;
         this.directory = dir.toAbsolutePath();
         this.executor = executor;
@@ -58,7 +57,7 @@ public class DirectoryWatchService implements AutoCloseable {
                         if (event.kind() == StandardWatchEventKinds.ENTRY_CREATE) {
                             Path filename = (Path) event.context();
                             Path file = directory.resolve(filename);
-                            String shorthand = shorthandParser.apply(file);
+                            String shorthand = shorthandParser.extract(file);
                             if (shorthand != null) {
                                 try {
                                     fileService.ingestFile(file, shorthand);

--- a/apps/ingest-service/src/main/java/org/artificers/ingest/FileIngestionService.java
+++ b/apps/ingest-service/src/main/java/org/artificers/ingest/FileIngestionService.java
@@ -8,16 +8,15 @@ import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
-import java.util.function.Function;
 
 /** Handles scanning directories and moving ingested files. */
 public class FileIngestionService {
     private static final Logger log = LoggerFactory.getLogger(FileIngestionService.class);
     private final IngestService ingestService;
-    private final Function<Path, String> shorthandParser;
+    private final AccountShorthandParser shorthandParser;
 
     public FileIngestionService(IngestService ingestService,
-                                Function<Path, String> shorthandParser) {
+                                AccountShorthandParser shorthandParser) {
         this.ingestService = ingestService;
         this.shorthandParser = shorthandParser;
     }
@@ -27,7 +26,7 @@ public class FileIngestionService {
         try (DirectoryStream<Path> stream = Files.newDirectoryStream(input, "*.csv")) {
             for (Path file : stream) {
                 log.info("Found file {}", file);
-                String shorthand = shorthandParser.apply(file);
+                String shorthand = shorthandParser.extract(file);
                 if (shorthand == null) {
                     log.warn("Skipping file {} with unrecognized name", file);
                     continue;

--- a/apps/ingest-service/src/main/java/org/artificers/ingest/IngestApp.java
+++ b/apps/ingest-service/src/main/java/org/artificers/ingest/IngestApp.java
@@ -27,19 +27,22 @@ public final class IngestApp implements Callable<Integer> {
     private final FileIngestionService fileService;
     private final DirectoryWatchService watchService;
     private final IngestConfig config;
+    private final AccountShorthandParser shorthandParser;
 
     public IngestApp(IngestService service, FileIngestionService fileService,
-                     DirectoryWatchService watchService, IngestConfig config) {
+                     DirectoryWatchService watchService, IngestConfig config,
+                     AccountShorthandParser shorthandParser) {
         this.service = service;
         this.fileService = fileService;
         this.watchService = watchService;
         this.config = config;
+        this.shorthandParser = shorthandParser;
     }
 
     @Override
     public Integer call() throws Exception {
         if (file != null) {
-            String shorthand = AccountResolver.extractShorthand(file);
+            String shorthand = shorthandParser.extract(file);
             boolean ok = shorthand != null && service.ingestFile(file, shorthand);
             if (!ok) {
                 log.warn("Ingestion failed for {}", file);
@@ -77,7 +80,8 @@ public final class IngestApp implements Callable<Integer> {
         IngestService service = component.ingestService();
         FileIngestionService fileService = component.fileIngestionService();
         DirectoryWatchService watch = component.directoryWatchService();
-        int code = new CommandLine(new IngestApp(service, fileService, watch, cfg)).execute(args);
+        AccountShorthandParser parser = component.accountShorthandParser();
+        int code = new CommandLine(new IngestApp(service, fileService, watch, cfg, parser)).execute(args);
         System.exit(code);
     }
 

--- a/apps/ingest-service/src/main/java/org/artificers/ingest/IngestComponent.java
+++ b/apps/ingest-service/src/main/java/org/artificers/ingest/IngestComponent.java
@@ -13,6 +13,7 @@ public interface IngestComponent {
     FileIngestionService fileIngestionService();
     DirectoryWatchService directoryWatchService();
     NewAccountCli newAccountCli();
+    AccountShorthandParser accountShorthandParser();
 
     @Component.Builder
     interface Builder {

--- a/apps/ingest-service/src/main/java/org/artificers/ingest/IngestService.java
+++ b/apps/ingest-service/src/main/java/org/artificers/ingest/IngestService.java
@@ -19,17 +19,20 @@ public class IngestService {
 
     private final DSLContext dsl;
     private final AccountResolver accountResolver;
+    private final AccountShorthandParser shorthandParser;
     private final Map<String, TransactionCsvReader> readers;
     private final TransactionRepository repository;
     private final MaterializedViewRefresher viewRefresher;
 
     public IngestService(DSLContext dsl,
                          AccountResolver accountResolver,
+                         AccountShorthandParser shorthandParser,
                          Set<TransactionCsvReader> readers,
                          TransactionRepository repository,
                          MaterializedViewRefresher viewRefresher) {
         this.dsl = dsl;
         this.accountResolver = accountResolver;
+        this.shorthandParser = shorthandParser;
         this.readers = readers.stream().collect(Collectors.toMap(TransactionCsvReader::institution, r -> r));
         this.repository = repository;
         this.viewRefresher = viewRefresher;
@@ -38,7 +41,7 @@ public class IngestService {
     public boolean ingestFile(Path file, String shorthand) {
         log.info("Ingesting file {} for shorthand {}", file, shorthand);
         try {
-            AccountResolver.ParsedShorthand ids = AccountResolver.parse(shorthand);
+            AccountShorthandParser.ParsedShorthand ids = shorthandParser.parse(shorthand);
             TransactionCsvReader reader = readers.get(ids.institution());
             if (reader == null) {
                 log.error("No reader for institution {}", ids.institution());

--- a/apps/ingest-service/src/test/java/org/artificers/ingest/AccountCreationIntegrationTest.java
+++ b/apps/ingest-service/src/test/java/org/artificers/ingest/AccountCreationIntegrationTest.java
@@ -16,6 +16,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class AccountCreationIntegrationTest {
     private DSLContext dsl;
     private AccountResolver resolver;
+    private AccountShorthandParser parser;
 
     @BeforeEach
     void setup() {
@@ -25,7 +26,8 @@ public class AccountCreationIntegrationTest {
         dsl.execute("drop table if exists accounts");
         dsl.execute("create table accounts (id serial primary key, institution varchar not null, external_id varchar not null, display_name varchar not null, created_at timestamp, updated_at timestamp)");
         dsl.execute("create unique index on accounts(institution, external_id)");
-        resolver = new AccountResolver(dsl);
+        parser = new AccountShorthandParser();
+        resolver = new AccountResolver(dsl, parser);
     }
 
     private Path copyResource(String resource) throws IOException {

--- a/apps/ingest-service/src/test/java/org/artificers/ingest/AccountResolverTest.java
+++ b/apps/ingest-service/src/test/java/org/artificers/ingest/AccountResolverTest.java
@@ -23,7 +23,8 @@ public class AccountResolverTest {
     @Test
     void insertsWhenMissing() {
         DSLContext dsl = initDsl();
-        AccountResolver resolver = new AccountResolver(dsl);
+        AccountShorthandParser parser = new AccountShorthandParser();
+        AccountResolver resolver = new AccountResolver(dsl, parser);
         long id1 = resolver.resolve("bank1234").id();
         long id2 = resolver.resolve("bank1234").id();
         assertEquals(id1, id2);
@@ -32,7 +33,8 @@ public class AccountResolverTest {
     @Test
     void throwsOnInvalidShorthand() {
         DSLContext dsl = initDsl();
-        AccountResolver resolver = new AccountResolver(dsl);
+        AccountShorthandParser parser = new AccountShorthandParser();
+        AccountResolver resolver = new AccountResolver(dsl, parser);
         assertThrows(IllegalArgumentException.class, () -> resolver.resolve("invalid"));
     }
 }

--- a/apps/ingest-service/src/test/java/org/artificers/ingest/DirectoryWatchServiceIntegrationTest.java
+++ b/apps/ingest-service/src/test/java/org/artificers/ingest/DirectoryWatchServiceIntegrationTest.java
@@ -30,10 +30,11 @@ class DirectoryWatchServiceIntegrationTest {
     void ingestsAndMovesNewCsvFiles(@TempDir Path dir) throws Exception {
         IngestService ingestService = mock(IngestService.class);
         when(ingestService.ingestFile(any(), any())).thenReturn(true);
-        FileIngestionService fileService = new FileIngestionService(ingestService, AccountResolver::extractShorthand);
+        AccountShorthandParser parser = new AccountShorthandParser();
+        FileIngestionService fileService = new FileIngestionService(ingestService, parser);
         ExecutorService executor = Executors.newSingleThreadExecutor();
         WatchService watchService = FileSystems.getDefault().newWatchService();
-        watcher = new DirectoryWatchService(fileService, dir, executor, watchService, AccountResolver::extractShorthand);
+        watcher = new DirectoryWatchService(fileService, dir, executor, watchService, parser);
         watcher.start();
 
         Path file = dir.resolve("ch1234-example.csv");
@@ -52,10 +53,11 @@ class DirectoryWatchServiceIntegrationTest {
     void movesFailedFilesAndContinuesWatching(@TempDir Path dir) throws Exception {
         IngestService ingestService = mock(IngestService.class);
         when(ingestService.ingestFile(any(), any())).thenReturn(false, true);
-        FileIngestionService fileService = new FileIngestionService(ingestService, AccountResolver::extractShorthand);
+        AccountShorthandParser parser = new AccountShorthandParser();
+        FileIngestionService fileService = new FileIngestionService(ingestService, parser);
         ExecutorService executor = Executors.newSingleThreadExecutor();
         WatchService watchService = FileSystems.getDefault().newWatchService();
-        watcher = new DirectoryWatchService(fileService, dir, executor, watchService, AccountResolver::extractShorthand);
+        watcher = new DirectoryWatchService(fileService, dir, executor, watchService, parser);
         watcher.start();
 
         Path bad = dir.resolve("ch1234-bad.csv");
@@ -84,10 +86,11 @@ class DirectoryWatchServiceIntegrationTest {
         Path file = dir.resolve("ch1234-existing.csv");
         Files.writeString(file, "id,amount\n1,10");
 
-        FileIngestionService fileService = new FileIngestionService(ingestService, AccountResolver::extractShorthand);
+        AccountShorthandParser parser = new AccountShorthandParser();
+        FileIngestionService fileService = new FileIngestionService(ingestService, parser);
         ExecutorService executor = Executors.newSingleThreadExecutor();
         WatchService watchService = FileSystems.getDefault().newWatchService();
-        watcher = new DirectoryWatchService(fileService, dir, executor, watchService, AccountResolver::extractShorthand);
+        watcher = new DirectoryWatchService(fileService, dir, executor, watchService, parser);
         watcher.start();
 
         Path processed = dir.resolve("processed").resolve("ch1234-existing.csv");

--- a/apps/ingest-service/src/test/java/org/artificers/ingest/FileIngestionServiceTest.java
+++ b/apps/ingest-service/src/test/java/org/artificers/ingest/FileIngestionServiceTest.java
@@ -26,6 +26,7 @@ class FileIngestionServiceTest {
         MockDataProvider provider = ctx -> new MockResult[0];
         DSLContext dsl = DSL.using(new MockConnection(provider), SQLDialect.POSTGRES);
         AccountResolver resolver = mock(AccountResolver.class);
+        AccountShorthandParser parser = new AccountShorthandParser();
         TransactionCsvReader chReader = mock(TransactionCsvReader.class);
         TransactionCsvReader coReader = mock(TransactionCsvReader.class);
         when(chReader.institution()).thenReturn("ch");
@@ -41,8 +42,8 @@ class FileIngestionServiceTest {
 
         TransactionRepository repo = new TransactionRepository();
         MaterializedViewRefresher refresher = new MaterializedViewRefresher(dsl);
-        IngestService service = new IngestService(dsl, resolver, Set.of(chReader, coReader), repo, refresher);
-        FileIngestionService fileService = new FileIngestionService(service, AccountResolver::extractShorthand);
+        IngestService service = new IngestService(dsl, resolver, parser, Set.of(chReader, coReader), repo, refresher);
+        FileIngestionService fileService = new FileIngestionService(service, parser);
         fileService.scanAndIngest(dir);
 
         verify(chReader).read(eq(dir.resolve("ch1234-example.csv")), any(), eq("1234"));

--- a/apps/ingest-service/src/test/java/org/artificers/ingest/IngestAppTest.java
+++ b/apps/ingest-service/src/test/java/org/artificers/ingest/IngestAppTest.java
@@ -17,8 +17,9 @@ class IngestAppTest {
         when(service.ingestFile(any(), any())).thenReturn(true);
         DirectoryWatchService watch = mock(DirectoryWatchService.class);
         IngestConfig cfg = new IngestConfig(Path.of("storage/incoming"), Path.of("cfg"));
+        AccountShorthandParser parser = new AccountShorthandParser();
 
-        int code = new CommandLine(new IngestApp(service, fileService, watch, cfg)).execute("--file=/tmp/ch1234.csv");
+        int code = new CommandLine(new IngestApp(service, fileService, watch, cfg, parser)).execute("--file=/tmp/ch1234.csv");
 
         verify(service).ingestFile(Path.of("/tmp/ch1234.csv"), "ch1234");
         assertThat(code).isZero();
@@ -30,8 +31,9 @@ class IngestAppTest {
         FileIngestionService fileService = mock(FileIngestionService.class);
         DirectoryWatchService watch = mock(DirectoryWatchService.class);
         IngestConfig cfg = new IngestConfig(Path.of("storage/incoming"), Path.of("cfg"));
+        AccountShorthandParser parser = new AccountShorthandParser();
 
-        int code = new CommandLine(new IngestApp(service, fileService, watch, cfg)).execute("--mode=scan", "--input=/tmp/in");
+        int code = new CommandLine(new IngestApp(service, fileService, watch, cfg, parser)).execute("--mode=scan", "--input=/tmp/in");
 
         verify(fileService).scanAndIngest(Path.of("/tmp/in"));
         assertThat(code).isZero();
@@ -43,8 +45,9 @@ class IngestAppTest {
         FileIngestionService fileService = mock(FileIngestionService.class);
         DirectoryWatchService watch = mock(DirectoryWatchService.class);
         IngestConfig cfg = new IngestConfig(Path.of("storage/incoming"), Path.of("cfg"));
+        AccountShorthandParser parser = new AccountShorthandParser();
 
-        int code = new CommandLine(new IngestApp(service, fileService, watch, cfg)).execute("--mode=scan");
+        int code = new CommandLine(new IngestApp(service, fileService, watch, cfg, parser)).execute("--mode=scan");
 
         verify(fileService).scanAndIngest(Path.of("storage/incoming"));
         assertThat(code).isZero();

--- a/apps/ingest-service/src/test/java/org/artificers/ingest/IngestServiceViewTest.java
+++ b/apps/ingest-service/src/test/java/org/artificers/ingest/IngestServiceViewTest.java
@@ -55,10 +55,11 @@ class IngestServiceViewTest {
         dsl.execute("create unique index on transactions(account_id, hash)");
 
         ConfigurableCsvReader reader = reader(institution);
-        AccountResolver resolver = new AccountResolver(dsl);
+        AccountShorthandParser parser = new AccountShorthandParser();
+        AccountResolver resolver = new AccountResolver(dsl, parser);
         TransactionRepository repo = new TransactionRepository();
         MaterializedViewRefresher refresher = new MaterializedViewRefresher(dsl);
-        IngestService service = new IngestService(dsl, resolver, Set.of(reader), repo, refresher);
+        IngestService service = new IngestService(dsl, resolver, parser, Set.of(reader), repo, refresher);
 
         Path file = copyResource("/examples/" + fileName, dir);
         boolean ok = service.ingestFile(file, institution + externalId);


### PR DESCRIPTION
## Summary
- extract shorthand parsing into AccountShorthandParser
- inject AccountShorthandParser across services instead of static methods
- wire parser into Dagger ServiceModule and component

## Testing
- `make deps` *(fails: No rule to make target 'deps')*
- `cd apps/ingest-service && ./gradlew test`
- `make build-app` *(fails: the server hosted at that remote is unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68bb56b643b88325ba36e344c8351bd7