### PR TITLE
Refactor CSV mapping with handlers

### DIFF
--- a/apps/ingest-service/src/main/java/org/artificers/ingest/FieldHandler.java
+++ b/apps/ingest-service/src/main/java/org/artificers/ingest/FieldHandler.java
@@ -1,0 +1,6 @@
+package org.artificers.ingest;
+
+@FunctionalInterface
+interface FieldHandler {
+    void handle(String header, String value, ConfigurableCsvReader.FieldSpec spec, RowBuilder builder);
+}


### PR DESCRIPTION
## Summary
- replace switch-based CSV field mapping with handler map
- add RowBuilder to accumulate parsed CSV values and build transactions

## Testing
- `cd apps/ingest-service && ./gradlew test`
- `make build-app` *(fails: Failure: the server hosted at that remote is unavailable.)*

------
https://chatgpt.com/codex/tasks/task_e_68bb59c7db608325bf6ca50f5f02f24b