### PR TITLE
Introduce pluggable TransactionValidator

### DIFF
--- a/apps/ingest-service/src/main/java/org/artificers/ingest/BasicTransactionValidator.java
+++ b/apps/ingest-service/src/main/java/org/artificers/ingest/BasicTransactionValidator.java
@@ -1,0 +1,21 @@
+package org.artificers.ingest;
+
+/** Basic implementation of {@link TransactionValidator}. */
+public final class BasicTransactionValidator implements TransactionValidator {
+    @Override
+    public void validate(TransactionRecord tx) {
+        if (tx.accountId() == null || tx.accountId().isBlank()) {
+            throw new IllegalArgumentException("accountId is required");
+        }
+        if (tx.amount() == null) {
+            throw new IllegalArgumentException("amount is required");
+        }
+        if (tx.amount().currency() == null || tx.amount().currency().length() != 3) {
+            throw new IllegalArgumentException("currency must be 3-letter code");
+        }
+        if (tx.hash() == null || tx.hash().isBlank()) {
+            throw new IllegalArgumentException("hash is required");
+        }
+    }
+}
+

--- a/apps/ingest-service/src/main/java/org/artificers/ingest/ConfigurableCsvReader.java
+++ b/apps/ingest-service/src/main/java/org/artificers/ingest/ConfigurableCsvReader.java
@@ -13,10 +13,12 @@ public class ConfigurableCsvReader extends BaseCsvReader implements TransactionC
     private final String institution;
     private final Map<String, FieldSpec> fields;
     private final ObjectMapper mapper;
+    private final TransactionValidator validator;
     private final Map<FieldTarget, FieldHandler> handlers;
 
-    public ConfigurableCsvReader(ObjectMapper mapper, Mapping mapping) {
+    public ConfigurableCsvReader(ObjectMapper mapper, TransactionValidator validator, Mapping mapping) {
         this.mapper = mapper;
+        this.validator = validator;
         this.institution = mapping.institution();
         this.fields = mapping.fields();
         this.handlers = initHandlers();
@@ -39,7 +41,7 @@ public class ConfigurableCsvReader extends BaseCsvReader implements TransactionC
     }
 
     private TransactionRecord mapRow(String accountId, String[] header, String[] row) {
-        RowBuilder builder = new RowBuilder(accountId, mapper);
+        RowBuilder builder = new RowBuilder(accountId, mapper, validator);
         for (int i = 0; i < header.length && i < row.length; i++) {
             String h = header[i];
             String v = row[i];

--- a/apps/ingest-service/src/main/java/org/artificers/ingest/CsvReaderModule.java
+++ b/apps/ingest-service/src/main/java/org/artificers/ingest/CsvReaderModule.java
@@ -13,26 +13,17 @@ import javax.inject.Singleton;
 /** Module for CSV reader configuration. */
 @Module
 public final class CsvReaderModule {
-    private final Set<TransactionCsvReader> readers;
-
-    public CsvReaderModule() {
-        this(new ObjectMapper());
-    }
-
-    CsvReaderModule(ObjectMapper mapper) {
+    @Provides
+    @Singleton
+    @ElementsIntoSet
+    static Set<TransactionCsvReader> csvReaders(ObjectMapper mapper, TransactionValidator validator) {
         try {
-            this.readers = new MappingFileLocator(mapper).locate().stream()
-                    .map(m -> new ConfigurableCsvReader(mapper, m))
+            return new MappingFileLocator(mapper).locate().stream()
+                    .map(m -> new ConfigurableCsvReader(mapper, validator, m))
                     .collect(Collectors.toUnmodifiableSet());
         } catch (IOException e) {
             throw new UncheckedIOException("Failed to load CSV mappings", e);
         }
     }
-
-    @Provides
-    @Singleton
-    @ElementsIntoSet
-    Set<TransactionCsvReader> csvReaders() {
-        return readers;
-    }
 }
+

--- a/apps/ingest-service/src/main/java/org/artificers/ingest/RowBuilder.java
+++ b/apps/ingest-service/src/main/java/org/artificers/ingest/RowBuilder.java
@@ -8,6 +8,7 @@ import java.util.Map;
 class RowBuilder {
     private final String accountId;
     private final ObjectMapper mapper;
+    private final TransactionValidator validator;
     private final Map<String, String> raw = new LinkedHashMap<>();
     private Instant occurredAt;
     private Instant postedAt;
@@ -17,9 +18,10 @@ class RowBuilder {
     private String type;
     private String memo;
 
-    RowBuilder(String accountId, ObjectMapper mapper) {
+    RowBuilder(String accountId, ObjectMapper mapper, TransactionValidator validator) {
         this.accountId = accountId;
         this.mapper = mapper;
+        this.validator = validator;
     }
 
     void occurredAt(Instant v) {
@@ -65,7 +67,7 @@ class RowBuilder {
         String hash = HashGenerator.sha256(accountId, amount, occurredAt, merchant);
         TransactionRecord tx = new GenericTransaction(accountId, occurredAt, postedAt, amount,
                 merchant, category, type, memo, hash, rawJson);
-        TransactionValidator.validate(tx);
+        validator.validate(tx);
         return tx;
     }
 }

--- a/apps/ingest-service/src/main/java/org/artificers/ingest/ServiceModule.java
+++ b/apps/ingest-service/src/main/java/org/artificers/ingest/ServiceModule.java
@@ -25,6 +25,12 @@ public interface ServiceModule {
 
     @Provides
     @Singleton
+    static TransactionValidator transactionValidator() {
+        return new BasicTransactionValidator();
+    }
+
+    @Provides
+    @Singleton
     static AccountShorthandParser accountShorthandParser() {
         return new AccountShorthandParser();
     }

--- a/apps/ingest-service/src/main/java/org/artificers/ingest/TransactionValidator.java
+++ b/apps/ingest-service/src/main/java/org/artificers/ingest/TransactionValidator.java
@@ -1,20 +1,7 @@
 package org.artificers.ingest;
 
-final class TransactionValidator {
-    private TransactionValidator() {}
-
-    static void validate(TransactionRecord tx) {
-        if (tx.accountId() == null || tx.accountId().isBlank()) {
-            throw new IllegalArgumentException("accountId is required");
-        }
-        if (tx.amount() == null) {
-            throw new IllegalArgumentException("amount is required");
-        }
-        if (tx.amount().currency() == null || tx.amount().currency().length() != 3) {
-            throw new IllegalArgumentException("currency must be 3-letter code");
-        }
-        if (tx.hash() == null || tx.hash().isBlank()) {
-            throw new IllegalArgumentException("hash is required");
-        }
-    }
+/** Validates {@link TransactionRecord} instances. */
+public interface TransactionValidator {
+    void validate(TransactionRecord tx);
 }
+

--- a/apps/ingest-service/src/test/java/org/artificers/ingest/AccountCreationIntegrationTest.java
+++ b/apps/ingest-service/src/test/java/org/artificers/ingest/AccountCreationIntegrationTest.java
@@ -44,7 +44,8 @@ public class AccountCreationIntegrationTest {
         try (InputStream in = getClass().getResourceAsStream("/mappings/" + institution + ".json")) {
             ConfigurableCsvReader.Mapping mapping =
                     new com.fasterxml.jackson.databind.ObjectMapper().readValue(in, ConfigurableCsvReader.Mapping.class);
-            return new ConfigurableCsvReader(new com.fasterxml.jackson.databind.ObjectMapper(), mapping);
+            return new ConfigurableCsvReader(new com.fasterxml.jackson.databind.ObjectMapper(),
+                    new BasicTransactionValidator(), mapping);
         }
     }
 

--- a/apps/ingest-service/src/test/java/org/artificers/ingest/ConfigurableCsvReaderTest.java
+++ b/apps/ingest-service/src/test/java/org/artificers/ingest/ConfigurableCsvReaderTest.java
@@ -14,7 +14,7 @@ class ConfigurableCsvReaderTest {
     private ConfigurableCsvReader reader(String name, ObjectMapper mapper) throws Exception {
         try (InputStream in = getClass().getResourceAsStream("/mappings/" + name + ".json")) {
             ConfigurableCsvReader.Mapping mapping = new ObjectMapper().readValue(in, ConfigurableCsvReader.Mapping.class);
-            return new ConfigurableCsvReader(mapper, mapping);
+            return new ConfigurableCsvReader(mapper, new BasicTransactionValidator(), mapping);
         }
     }
 
@@ -70,7 +70,7 @@ class ConfigurableCsvReaderTest {
                 "\"credit\":{\"target\":\"AMOUNT_CENTS\",\"type\":\"int\"}" +
                 "}}";
         ConfigurableCsvReader.Mapping m = new ObjectMapper().readValue(mapping, ConfigurableCsvReader.Mapping.class);
-        ConfigurableCsvReader reader = new ConfigurableCsvReader(new ObjectMapper(), m);
+        ConfigurableCsvReader reader = new ConfigurableCsvReader(new ObjectMapper(), new BasicTransactionValidator(), m);
         String csv = "date,debit,credit\n" +
                 "2025-04-30,100,0\n" +
                 "2025-04-29,0,200\n";

--- a/apps/ingest-service/src/test/java/org/artificers/ingest/IngestServiceViewTest.java
+++ b/apps/ingest-service/src/test/java/org/artificers/ingest/IngestServiceViewTest.java
@@ -21,7 +21,7 @@ class IngestServiceViewTest {
         try (InputStream in = getClass().getResourceAsStream("/mappings/" + institution + ".json")) {
             ConfigurableCsvReader.Mapping mapping =
                     new ObjectMapper().readValue(in, ConfigurableCsvReader.Mapping.class);
-            return new ConfigurableCsvReader(new ObjectMapper(), mapping);
+            return new ConfigurableCsvReader(new ObjectMapper(), new BasicTransactionValidator(), mapping);
         }
     }
 


### PR DESCRIPTION
## Summary
- Replace static transaction validation with `TransactionValidator` interface and `BasicTransactionValidator` implementation
- Inject validator into `ConfigurableCsvReader` and related modules
- Provide validator via Dagger and update tests

## Testing
- `make deps` (failed: No rule to make target 'deps')
- `cd apps/ingest-service && ./gradlew test`
- `make build-app` (failed: server hosted at remote is unavailable)

------
https://chatgpt.com/codex/tasks/task_e_68bb5e9086888325b251fa396932b431