### PR TITLE
Refactor ingestion service into explicit helpers

### DIFF
--- a/apps/ingest-service/src/main/java/org/artificers/ingest/FileIngestionService.java
+++ b/apps/ingest-service/src/main/java/org/artificers/ingest/FileIngestionService.java
@@ -37,9 +37,15 @@ public class FileIngestionService {
     }
 
     public void ingestFile(Path file, String shorthand) throws IOException {
-        boolean ok = ingestService.ingestFile(file, shorthand);
-        log.info("Ingestion {} for file {}", ok ? "succeeded" : "failed", file);
-        Path targetDir = file.getParent().resolve(ok ? "processed" : "error");
+        Path targetDir;
+        try {
+            ingestService.ingestFile(file, shorthand);
+            log.info("Ingestion succeeded for file {}", file);
+            targetDir = file.getParent().resolve("processed");
+        } catch (Exception e) {
+            log.info("Ingestion failed for file {}", file, e);
+            targetDir = file.getParent().resolve("error");
+        }
         Files.createDirectories(targetDir);
         Files.move(file, targetDir.resolve(file.getFileName()), StandardCopyOption.REPLACE_EXISTING);
     }

--- a/apps/ingest-service/src/main/java/org/artificers/ingest/IngestApp.java
+++ b/apps/ingest-service/src/main/java/org/artificers/ingest/IngestApp.java
@@ -43,9 +43,14 @@ public final class IngestApp implements Callable<Integer> {
     public Integer call() throws Exception {
         if (file != null) {
             String shorthand = shorthandParser.extract(file);
-            boolean ok = shorthand != null && service.ingestFile(file, shorthand);
-            if (!ok) {
-                log.warn("Ingestion failed for {}", file);
+            if (shorthand != null) {
+                try {
+                    service.ingestFile(file, shorthand);
+                } catch (Exception e) {
+                    log.warn("Ingestion failed for {}", file, e);
+                }
+            } else {
+                log.warn("Skipping file {} with unrecognized name", file);
             }
             return 0;
         }

--- a/apps/ingest-service/src/main/java/org/artificers/ingest/IngestException.java
+++ b/apps/ingest-service/src/main/java/org/artificers/ingest/IngestException.java
@@ -1,0 +1,12 @@
+package org.artificers.ingest;
+
+/** General checked exception for ingestion failures. */
+public class IngestException extends Exception {
+    public IngestException(String message) {
+        super(message);
+    }
+
+    public IngestException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/apps/ingest-service/src/test/java/org/artificers/ingest/DirectoryWatchServiceIntegrationTest.java
+++ b/apps/ingest-service/src/test/java/org/artificers/ingest/DirectoryWatchServiceIntegrationTest.java
@@ -29,7 +29,7 @@ class DirectoryWatchServiceIntegrationTest {
     @Test
     void ingestsAndMovesNewCsvFiles(@TempDir Path dir) throws Exception {
         IngestService ingestService = mock(IngestService.class);
-        when(ingestService.ingestFile(any(), any())).thenReturn(true);
+        doNothing().when(ingestService).ingestFile(any(), any());
         AccountShorthandParser parser = new AccountShorthandParser();
         FileIngestionService fileService = new FileIngestionService(ingestService, parser);
         ExecutorService executor = Executors.newSingleThreadExecutor();
@@ -52,7 +52,8 @@ class DirectoryWatchServiceIntegrationTest {
     @Test
     void movesFailedFilesAndContinuesWatching(@TempDir Path dir) throws Exception {
         IngestService ingestService = mock(IngestService.class);
-        when(ingestService.ingestFile(any(), any())).thenReturn(false, true);
+        doThrow(new IngestException("fail")).doNothing()
+                .when(ingestService).ingestFile(any(), any());
         AccountShorthandParser parser = new AccountShorthandParser();
         FileIngestionService fileService = new FileIngestionService(ingestService, parser);
         ExecutorService executor = Executors.newSingleThreadExecutor();
@@ -82,7 +83,7 @@ class DirectoryWatchServiceIntegrationTest {
     @Test
     void processesExistingFilesOnStartup(@TempDir Path dir) throws Exception {
         IngestService ingestService = mock(IngestService.class);
-        when(ingestService.ingestFile(any(), any())).thenReturn(true);
+        doNothing().when(ingestService).ingestFile(any(), any());
         Path file = dir.resolve("ch1234-existing.csv");
         Files.writeString(file, "id,amount\n1,10");
 

--- a/apps/ingest-service/src/test/java/org/artificers/ingest/IngestAppTest.java
+++ b/apps/ingest-service/src/test/java/org/artificers/ingest/IngestAppTest.java
@@ -14,7 +14,7 @@ class IngestAppTest {
     void ingestsFileWhenFileOptionPresent() throws Exception {
         IngestService service = mock(IngestService.class);
         FileIngestionService fileService = mock(FileIngestionService.class);
-        when(service.ingestFile(any(), any())).thenReturn(true);
+        doNothing().when(service).ingestFile(any(), any());
         DirectoryWatchService watch = mock(DirectoryWatchService.class);
         IngestConfig cfg = new IngestConfig(Path.of("storage/incoming"), Path.of("cfg"));
         AccountShorthandParser parser = new AccountShorthandParser();

--- a/apps/ingest-service/src/test/java/org/artificers/ingest/IngestServiceTransactionTest.java
+++ b/apps/ingest-service/src/test/java/org/artificers/ingest/IngestServiceTransactionTest.java
@@ -40,9 +40,7 @@ class IngestServiceTransactionTest {
         TransactionRepository repo = new TransactionRepository();
         MaterializedViewRefresher refresher = new MaterializedViewRefresher(dsl);
         IngestService service = new IngestService(dsl, resolver, parser, Set.of(reader), repo, refresher);
-        boolean ok = service.ingestFile(dir.resolve(institution + "1234.csv"), institution + "1234");
-
-        assertThat(ok).isTrue();
+        service.ingestFile(dir.resolve(institution + "1234.csv"), institution + "1234");
         assertThat(dsl.fetchCount(DSL.table("transactions"))).isEqualTo(1);
     }
 }

--- a/apps/ingest-service/src/test/java/org/artificers/ingest/IngestServiceViewTest.java
+++ b/apps/ingest-service/src/test/java/org/artificers/ingest/IngestServiceViewTest.java
@@ -62,9 +62,7 @@ class IngestServiceViewTest {
         IngestService service = new IngestService(dsl, resolver, parser, Set.of(reader), repo, refresher);
 
         Path file = copyResource("/examples/" + fileName, dir);
-        boolean ok = service.ingestFile(file, institution + externalId);
-
-        assertThat(ok).isTrue();
+        service.ingestFile(file, institution + externalId);
         assertThat(
                 dsl.fetchCount(
                         DSL.table("transactions"),


### PR DESCRIPTION
## Summary
- Break down `ingestFile` into `parseTransactions`, `persistTransactions`, and `refreshViews`
- Use checked `IngestException` to surface failures instead of boolean returns
- Update consumers and tests for the new exception-driven workflow

## Testing
- `make deps` *(fails: No rule to make target 'deps')*
- `gradle wrapper`
- `./gradlew test`
- `make build-app` *(fails: server hosted at remote unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68bb60d05f448325ac44d1a64b473eaa