### PR TITLE
Use canonical delimiter for transaction hash

### DIFF
--- a/apps/ingest-service/src/main/java/org/artificers/ingest/HashGenerator.java
+++ b/apps/ingest-service/src/main/java/org/artificers/ingest/HashGenerator.java
@@ -7,7 +7,17 @@ final class HashGenerator {
     private HashGenerator() {}
 
     static String sha256(String accountId, Money amount, Instant occurredAt, String merchant) {
-        String occurred = occurredAt == null ? "" : occurredAt.toString();
-        return DigestUtils.sha256Hex(accountId + amount.cents() + amount.currency() + occurred + merchant);
+        String canonical = String.join(
+                "|",
+                normalize(accountId),
+                normalize(amount == null ? null : Long.toString(amount.cents())),
+                normalize(amount == null ? null : amount.currency()),
+                normalize(occurredAt == null ? null : occurredAt.toString()),
+                normalize(merchant));
+        return DigestUtils.sha256Hex(canonical);
+    }
+
+    private static String normalize(String value) {
+        return value == null ? "" : value;
     }
 }

--- a/apps/ingest-service/src/test/java/org/artificers/ingest/HashGeneratorTest.java
+++ b/apps/ingest-service/src/test/java/org/artificers/ingest/HashGeneratorTest.java
@@ -1,0 +1,26 @@
+package org.artificers.ingest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+class HashGeneratorTest {
+
+    @Test
+    void identicalInputsProduceSameHash() {
+        Money amount = new Money(123L, "USD");
+        Instant occurred = Instant.parse("2024-01-01T00:00:00Z");
+
+        String hash1 = HashGenerator.sha256("acct", amount, occurred, "merchant");
+        String hash2 = HashGenerator.sha256("acct", amount, occurred, "merchant");
+
+        assertEquals(hash1, hash2);
+
+        String nullHash1 = HashGenerator.sha256(null, null, null, null);
+        String nullHash2 = HashGenerator.sha256(null, null, null, null);
+
+        assertEquals(nullHash1, nullHash2);
+    }
+}
+


### PR DESCRIPTION
## Summary
- generate transaction hash from canonical `String.join` representation with null-safe normalization
- add unit test to ensure identical inputs always produce the same hash

## Testing
- `make deps` *(fails: No rule to make target 'deps')*
- `cd apps/ingest-service && ./gradlew test`
- `make build-app` *(fails: Failure: the server hosted at that remote is unavailable.)*

------
https://chatgpt.com/codex/tasks/task_e_68bb6a02c530832598b545d838534c2f