### PR TITLE
feat: close datasource on shutdown

### DIFF
--- a/apps/ingest-service/src/main/java/org/artificers/ingest/DataModule.java
+++ b/apps/ingest-service/src/main/java/org/artificers/ingest/DataModule.java
@@ -4,13 +4,20 @@ import com.zaxxer.hikari.HikariDataSource;
 import dagger.Module;
 import dagger.Provides;
 import javax.inject.Singleton;
+import java.io.Closeable;
 import org.jooq.DSLContext;
 import org.jooq.SQLDialect;
 import org.jooq.impl.DSL;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** Module providing database access objects. */
+/**
+ * Module providing database access objects.
+ *
+ * <p>The {@link HikariDataSource} is a singleton that must be closed when the
+ * application shuts down. A {@link Closeable} handle is exposed so callers can
+ * register a shutdown hook or otherwise ensure the datasource is closed.
+ */
 @Module
 public interface DataModule {
     Logger LOG = LoggerFactory.getLogger(DataModule.class);
@@ -24,6 +31,12 @@ public interface DataModule {
         ds.setUsername(cfg.user());
         ds.setPassword(cfg.password());
         return ds;
+    }
+
+    @Provides
+    @Singleton
+    static Closeable dataSourceCloser(HikariDataSource ds) {
+        return ds::close;
     }
 
     @Provides

--- a/apps/ingest-service/src/main/java/org/artificers/ingest/IngestApp.java
+++ b/apps/ingest-service/src/main/java/org/artificers/ingest/IngestApp.java
@@ -6,6 +6,8 @@ import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.concurrent.Callable;
 
@@ -82,6 +84,14 @@ public final class IngestApp implements Callable<Integer> {
                 .dbConfig(dbCfg)
                 .ingestConfig(cfg)
                 .build();
+        Closeable ds = component.dataSourceCloseable();
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            try {
+                ds.close();
+            } catch (IOException e) {
+                log.warn("Error closing datasource", e);
+            }
+        }));
         IngestService service = component.ingestService();
         FileIngestionService fileService = component.fileIngestionService();
         DirectoryWatchService watch = component.directoryWatchService();

--- a/apps/ingest-service/src/main/java/org/artificers/ingest/IngestComponent.java
+++ b/apps/ingest-service/src/main/java/org/artificers/ingest/IngestComponent.java
@@ -3,6 +3,7 @@ package org.artificers.ingest;
 import dagger.BindsInstance;
 import dagger.Component;
 import javax.inject.Singleton;
+import java.io.Closeable;
 import org.artificers.ingest.cli.NewAccountCli;
 
 /** Dagger component assembling ingest services. */
@@ -14,6 +15,7 @@ public interface IngestComponent {
     DirectoryWatchService directoryWatchService();
     NewAccountCli newAccountCli();
     AccountShorthandParser accountShorthandParser();
+    Closeable dataSourceCloseable();
 
     @Component.Builder
     interface Builder {


### PR DESCRIPTION
## Summary
- expose singleton HikariDataSource close handle
- add shutdown hook to release datasource

## Testing
- `make deps` *(fails: No rule to make target 'deps')*
- `cd apps/ingest-service && ./gradlew test`
- `make build-app` *(fails: Failure: the server hosted at that remote is unavailable.)*

------
https://chatgpt.com/codex/tasks/task_e_68bb6b7d5a788325aedd76dd682c3c36