### PR TITLE
Refactor ResolvedAccount to record

### DIFF
--- a/apps/ingest-service/src/main/java/org/artificers/ingest/ResolvedAccount.java
+++ b/apps/ingest-service/src/main/java/org/artificers/ingest/ResolvedAccount.java
@@ -1,17 +1,7 @@
 package org.artificers.ingest;
 
-public final class ResolvedAccount {
-    private final long id;
-    private final String institution;
-    private final String externalId;
+/**
+ * Represents an account resolved from shorthand notation.
+ */
+public record ResolvedAccount(long id, String institution, String externalId) {}
 
-    public ResolvedAccount(long id, String institution, String externalId) {
-        this.id = id;
-        this.institution = institution;
-        this.externalId = externalId;
-    }
-
-    public long id() { return id; }
-    public String institution() { return institution; }
-    public String externalId() { return externalId; }
-}

--- a/apps/ingest-service/src/test/java/org/artificers/ingest/ResolvedAccountTest.java
+++ b/apps/ingest-service/src/test/java/org/artificers/ingest/ResolvedAccountTest.java
@@ -1,0 +1,24 @@
+package org.artificers.ingest;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ResolvedAccountTest {
+
+    @Test
+    void equalityAndSerialization() throws Exception {
+        ResolvedAccount first = new ResolvedAccount(1L, "bank", "ext");
+        ResolvedAccount second = new ResolvedAccount(1L, "bank", "ext");
+
+        assertThat(first).isEqualTo(second);
+
+        ObjectMapper mapper = new ObjectMapper();
+        String json = mapper.writeValueAsString(first);
+        assertThat(json).isEqualTo("{\"id\":1,\"institution\":\"bank\",\"externalId\":\"ext\"}");
+        ResolvedAccount roundTrip = mapper.readValue(json, ResolvedAccount.class);
+        assertThat(roundTrip).isEqualTo(first);
+    }
+}
+


### PR DESCRIPTION
## Summary
- use Java record for ResolvedAccount
- add unit test validating equality and JSON serialization

## Testing
- `make deps` *(fails: No rule to make target 'deps')*
- `cd apps/ingest-service && ./gradlew test`
- `make build-app` *(fails: Failure: the server hosted at that remote is unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68bb6f388ba48325aa018b5ca78d0336