### PR TITLE
Use ExecutionMode enum for ingest modes

### DIFF
--- a/apps/ingest-service/src/main/java/org/artificers/ingest/ExecutionMode.java
+++ b/apps/ingest-service/src/main/java/org/artificers/ingest/ExecutionMode.java
@@ -1,0 +1,7 @@
+package org.artificers.ingest;
+
+/** Supported modes for the ingest application. */
+public enum ExecutionMode {
+    WATCH,
+    SCAN
+}

--- a/apps/ingest-service/src/main/java/org/artificers/ingest/IngestApp.java
+++ b/apps/ingest-service/src/main/java/org/artificers/ingest/IngestApp.java
@@ -19,8 +19,9 @@ public final class IngestApp implements Callable<Integer> {
     @Option(names = "--file", description = "Path to a CSV file")
     Path file;
 
-    @Option(names = "--mode", description = "Execution mode")
-    String mode;
+    @Option(names = "--mode", description = "Execution mode", type = ExecutionMode.class,
+            defaultValue = "WATCH")
+    ExecutionMode mode;
 
     @Option(names = "--input", description = "Directory to scan")
     Path input;
@@ -56,7 +57,7 @@ public final class IngestApp implements Callable<Integer> {
             }
             return 0;
         }
-        if ("scan".equals(mode)) {
+        if (mode == ExecutionMode.SCAN) {
             Path dir = input != null ? input : config.ingestDir();
             fileService.scanAndIngest(dir);
             return 0;
@@ -96,7 +97,9 @@ public final class IngestApp implements Callable<Integer> {
         FileIngestionService fileService = component.fileIngestionService();
         DirectoryWatchService watch = component.directoryWatchService();
         AccountShorthandParser parser = component.accountShorthandParser();
-        int code = new CommandLine(new IngestApp(service, fileService, watch, cfg, parser)).execute(args);
+        CommandLine cmd = new CommandLine(new IngestApp(service, fileService, watch, cfg, parser));
+        cmd.setCaseInsensitiveEnumValuesAllowed(true);
+        int code = cmd.execute(args);
         System.exit(code);
     }
 

--- a/apps/ingest-service/src/test/java/org/artificers/ingest/IngestAppTest.java
+++ b/apps/ingest-service/src/test/java/org/artificers/ingest/IngestAppTest.java
@@ -19,7 +19,9 @@ class IngestAppTest {
         IngestConfig cfg = new IngestConfig(Path.of("storage/incoming"), Path.of("cfg"));
         AccountShorthandParser parser = new AccountShorthandParser();
 
-        int code = new CommandLine(new IngestApp(service, fileService, watch, cfg, parser)).execute("--file=/tmp/ch1234.csv");
+        CommandLine cmd = new CommandLine(new IngestApp(service, fileService, watch, cfg, parser));
+        cmd.setCaseInsensitiveEnumValuesAllowed(true);
+        int code = cmd.execute("--file=/tmp/ch1234.csv");
 
         verify(service).ingestFile(Path.of("/tmp/ch1234.csv"), "ch1234");
         assertThat(code).isZero();
@@ -33,7 +35,9 @@ class IngestAppTest {
         IngestConfig cfg = new IngestConfig(Path.of("storage/incoming"), Path.of("cfg"));
         AccountShorthandParser parser = new AccountShorthandParser();
 
-        int code = new CommandLine(new IngestApp(service, fileService, watch, cfg, parser)).execute("--mode=scan", "--input=/tmp/in");
+        CommandLine cmd = new CommandLine(new IngestApp(service, fileService, watch, cfg, parser));
+        cmd.setCaseInsensitiveEnumValuesAllowed(true);
+        int code = cmd.execute("--mode=scan", "--input=/tmp/in");
 
         verify(fileService).scanAndIngest(Path.of("/tmp/in"));
         assertThat(code).isZero();
@@ -47,7 +51,9 @@ class IngestAppTest {
         IngestConfig cfg = new IngestConfig(Path.of("storage/incoming"), Path.of("cfg"));
         AccountShorthandParser parser = new AccountShorthandParser();
 
-        int code = new CommandLine(new IngestApp(service, fileService, watch, cfg, parser)).execute("--mode=scan");
+        CommandLine cmd = new CommandLine(new IngestApp(service, fileService, watch, cfg, parser));
+        cmd.setCaseInsensitiveEnumValuesAllowed(true);
+        int code = cmd.execute("--mode=scan");
 
         verify(fileService).scanAndIngest(Path.of("storage/incoming"));
         assertThat(code).isZero();


### PR DESCRIPTION
## Summary
- add `ExecutionMode` enum for WATCH and SCAN modes
- switch IngestApp `--mode` option to use the enum and enable case-insensitive parsing
- update tests for enum-based mode handling

## Testing
- `make deps` *(fails: No rule to make target 'deps')*
- `cd apps/ingest-service && ./gradlew test`
- `make build-app` *(fails: the server hosted at that remote is unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68bb71fc343483259f360e08edc91e93