### PR TITLE
Add parser and repository tests

### DIFF
--- a/apps/ingest-service/src/test/java/org/artificers/ingest/AccountShorthandParserTest.java
+++ b/apps/ingest-service/src/test/java/org/artificers/ingest/AccountShorthandParserTest.java
@@ -1,0 +1,38 @@
+package org.artificers.ingest;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.io.InputStream;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AccountShorthandParserTest {
+    @Test
+    void parsesUsingSampleMapping() throws Exception {
+        try (InputStream in = getClass().getResourceAsStream("/mappings/co.json")) {
+            ConfigurableCsvReader.Mapping mapping = new ObjectMapper().readValue(in, ConfigurableCsvReader.Mapping.class);
+            String shorthand = mapping.institution() + "1828";
+            AccountShorthandParser parser = new AccountShorthandParser();
+            AccountShorthandParser.ParsedShorthand ids = parser.parse(shorthand);
+            assertEquals(mapping.institution(), ids.institution());
+            assertEquals("1828", ids.externalId());
+        }
+    }
+
+    @Test
+    void extractsFromCsvFilename() {
+        AccountShorthandParser parser = new AccountShorthandParser();
+        assertEquals("ch1234", parser.extract(Path.of("ch1234.csv")));
+        assertNull(parser.extract(Path.of("note.txt")));
+    }
+
+    @Test
+    void rejectsInvalidStrings() {
+        AccountShorthandParser parser = new AccountShorthandParser();
+        assertThrows(IllegalArgumentException.class, () -> parser.parse("bad"));
+        assertThrows(IllegalArgumentException.class, () -> parser.parse(null));
+    }
+}
+

--- a/apps/ingest-service/src/test/java/org/artificers/ingest/ConfigurableCsvReaderTest.java
+++ b/apps/ingest-service/src/test/java/org/artificers/ingest/ConfigurableCsvReaderTest.java
@@ -97,4 +97,13 @@ class ConfigurableCsvReaderTest {
         reader.read(null, new StringReader(csv), "1234");
         assertTrue(mapper.calls > 0);
     }
+
+    @Test
+    void capturesUnmappedColumns() throws Exception {
+        String csv = "Transaction Date,Post Date,Description,Category,Type,Amount,Memo,Extra\n" +
+                "04/30/2025,04/30/2025,Payment Thank You-Mobile,,Payment,18.62,,note\n";
+        ConfigurableCsvReader reader = reader("ch", new ObjectMapper());
+        TransactionRecord tx = reader.read(null, new StringReader(csv), "1234").get(0);
+        assertTrue(tx.rawJson().contains("\"extra\":\"note\""));
+    }
 }

--- a/apps/ingest-service/src/test/java/org/artificers/ingest/JdbcUrlTest.java
+++ b/apps/ingest-service/src/test/java/org/artificers/ingest/JdbcUrlTest.java
@@ -19,4 +19,10 @@ class JdbcUrlTest {
     void convertsPostgresAlias() {
         assertEquals("jdbc:postgresql://host/db", JdbcUrl.from("postgres://host/db"));
     }
+
+    @Test
+    void returnsNullForNullUrl() {
+        assertNull(JdbcUrl.from(null));
+    }
 }
+

--- a/apps/ingest-service/src/test/java/org/artificers/ingest/TransactionRepositoryTest.java
+++ b/apps/ingest-service/src/test/java/org/artificers/ingest/TransactionRepositoryTest.java
@@ -1,0 +1,49 @@
+package org.artificers.ingest;
+
+import org.artificers.jooq.tables.Accounts;
+import org.artificers.jooq.tables.Transactions;
+import org.jooq.DSLContext;
+import org.jooq.impl.DSL;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.OffsetDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class TransactionRepositoryTest {
+    private DSLContext dsl;
+
+    @BeforeEach
+    void setup() {
+        dsl = DSL.using("jdbc:h2:mem:test;MODE=PostgreSQL;DATABASE_TO_UPPER=false", "sa", "");
+        dsl.execute("create domain if not exists jsonb as varchar");
+        dsl.execute("drop table if exists transactions");
+        dsl.execute("drop table if exists accounts");
+        dsl.execute("create table accounts (id bigserial primary key, institution varchar not null, external_id varchar not null, display_name varchar not null, created_at timestamp, updated_at timestamp)");
+        dsl.execute("create table transactions (id bigserial primary key, account_id bigint not null, occurred_at timestamp with time zone, posted_at timestamp with time zone, amount_cents bigint not null, currency varchar not null, merchant varchar, category varchar, memo varchar, txn_type varchar, hash varchar not null, raw_json jsonb not null, created_at timestamp with time zone, unique(account_id, hash))");
+        dsl.insertInto(Accounts.ACCOUNTS)
+                .set(Accounts.ACCOUNTS.ID, 1L)
+                .set(Accounts.ACCOUNTS.INSTITUTION, "co")
+                .set(Accounts.ACCOUNTS.EXTERNAL_ID, "1234")
+                .set(Accounts.ACCOUNTS.DISPLAY_NAME, "1234")
+                .set(Accounts.ACCOUNTS.CREATED_AT, OffsetDateTime.now())
+                .set(Accounts.ACCOUNTS.UPDATED_AT, OffsetDateTime.now())
+                .execute();
+    }
+
+    @Test
+    void upsertIgnoresDuplicatesOnHash() {
+        TransactionRepository repo = new TransactionRepository();
+        ResolvedAccount account = new ResolvedAccount(1L, "co", "1234");
+        TransactionRecord t1 = new GenericTransaction("1234", null, null, new Money(100, "USD"), "m", null, null, null, "h1", "{}");
+        TransactionRecord t2 = new GenericTransaction("1234", null, null, new Money(200, "USD"), "m", null, null, null, "h1", "{}");
+        repo.upsert(dsl, t1, account);
+        repo.upsert(dsl, t2, account);
+        assertEquals(1, dsl.fetchCount(Transactions.TRANSACTIONS));
+        TransactionRecord t3 = new GenericTransaction("1234", null, null, new Money(300, "USD"), "m", null, null, null, "h2", "{}");
+        repo.upsert(dsl, t3, account);
+        assertEquals(2, dsl.fetchCount(Transactions.TRANSACTIONS));
+    }
+}
+


### PR DESCRIPTION
## Summary
- add AccountShorthandParser tests using sample mapping
- extend JdbcUrl and ConfigurableCsvReader tests
- verify TransactionRepository with in-memory H2 database

## Testing
- `make deps` (fails: No rule to make target 'deps')
- `cd apps/ingest-service && ./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68bb73c46edc832598e305c00d8ad30d