### PR TITLE
test: drop dependent view before transaction table

### DIFF
--- a/apps/ingest-service/src/test/java/org/artificers/ingest/TransactionRepositoryTest.java
+++ b/apps/ingest-service/src/test/java/org/artificers/ingest/TransactionRepositoryTest.java
@@ -18,6 +18,7 @@ class TransactionRepositoryTest {
     void setup() {
         dsl = DSL.using("jdbc:h2:mem:test;MODE=PostgreSQL;DATABASE_TO_UPPER=false", "sa", "");
         dsl.execute("create domain if not exists jsonb as varchar");
+        dsl.execute("drop view if exists transactions_view");
         dsl.execute("drop table if exists transactions");
         dsl.execute("drop table if exists accounts");
         dsl.execute("create table accounts (id bigserial primary key, institution varchar not null, external_id varchar not null, display_name varchar not null, created_at timestamp, updated_at timestamp)");


### PR DESCRIPTION
## Summary
- drop `transactions_view` prior to resetting tables in `TransactionRepositoryTest`

## Testing
- `./gradlew test`
- `make build-app` *(fails: buf: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb8b7ace08832586e466835c20e2e2